### PR TITLE
fix: remove pool tokens from balancer pools to prevent infinite loops

### DIFF
--- a/y/prices/dex/balancer/balancer.py
+++ b/y/prices/dex/balancer/balancer.py
@@ -9,8 +9,6 @@ from y.datatypes import AnyAddressType, Block, UsdPrice
 from y.networks import Network
 from y.prices.dex.balancer.v1 import BalancerV1
 from y.prices.dex.balancer.v2 import BalancerV2
-from y.utils.logging import yLazyLogger
-from y.exceptions import PriceError
 
 logger = logging.getLogger(__name__)
 

--- a/y/prices/dex/balancer/balancer.py
+++ b/y/prices/dex/balancer/balancer.py
@@ -63,10 +63,7 @@ class BalancerMultiplexer:
     @alru_cache(maxsize=None)
     async def get_price_async(self, token_address: AnyAddressType, block: Optional[Block] = None) -> Optional[UsdPrice]:
         if await self.is_balancer_pool_async(token_address):
-            try:
-                return await self.get_pool_price_async(token_address, block=block)
-            except PriceError:
-                return None
+            return await self.get_pool_price_async(token_address, block=block)
 
         price = None
         

--- a/y/prices/dex/balancer/v2.py
+++ b/y/prices/dex/balancer/v2.py
@@ -184,7 +184,7 @@ class BalancerV2Pool(ERC20):
     #yLazyLogger(logger)
     async def tokens_async(self, block: Optional[Block] = None) -> Dict[ERC20, WeiBalance]:
         tokens, balances, lastChangedBlock = await self.vault.get_pool_tokens_async(self.id, block=block)
-        return {ERC20(token): WeiBalance(balance, token, block=block) for token, balance in zip(tokens, balances)}
+        return {ERC20(token): WeiBalance(balance, token, block=block) for token, balance in zip(tokens, balances) if token != self.address}
 
     #yLazyLogger(logger)
     def weights(self, block: Optional[Block] = None) -> List[int]:

--- a/y/prices/dex/balancer/v2.py
+++ b/y/prices/dex/balancer/v2.py
@@ -140,7 +140,7 @@ class BalancerV2Pool(ERC20):
     #yLazyLogger(logger)
     async def get_tvl_async(self, block: Optional[Block] = None) -> Awaitable[UsdValue]:
         balances = await self.get_balances_async(block=block)
-        return UsdValue(sum(await gather([balance.value_usd_async for balance in balances.values()])))
+        return UsdValue(sum(await gather([balance.value_usd_async for balance in balances.values() if balance.token.address != self.address])))
 
     def get_balances(self, block: Optional[Block] = None) -> Dict[ERC20, WeiBalance]:
         return await_awaitable(self.get_balances_async(block=block))
@@ -184,7 +184,7 @@ class BalancerV2Pool(ERC20):
     #yLazyLogger(logger)
     async def tokens_async(self, block: Optional[Block] = None) -> Dict[ERC20, WeiBalance]:
         tokens, balances, lastChangedBlock = await self.vault.get_pool_tokens_async(self.id, block=block)
-        return {ERC20(token): WeiBalance(balance, token, block=block) for token, balance in zip(tokens, balances) if token != self.address}
+        return {ERC20(token): WeiBalance(balance, token, block=block) for token, balance in zip(tokens, balances)}
 
     #yLazyLogger(logger)
     def weights(self, block: Optional[Block] = None) -> List[int]:

--- a/y/prices/dex/balancer/v2.py
+++ b/y/prices/dex/balancer/v2.py
@@ -140,7 +140,10 @@ class BalancerV2Pool(ERC20):
     #yLazyLogger(logger)
     async def get_tvl_async(self, block: Optional[Block] = None) -> Awaitable[UsdValue]:
         balances = await self.get_balances_async(block=block)
-        return UsdValue(sum(await gather([balance.value_usd_async for balance in balances.values() if balance.token.address != self.address])))
+        return UsdValue(sum(await gather([
+            balance.value_usd_async for balance in balances.values()
+            if balance.token.address != self.address  # NOTE: to prevent an infinite loop for tokens that include themselves in the pool (e.g. bb-a-USDC)
+        ])))
 
     def get_balances(self, block: Optional[Block] = None) -> Dict[ERC20, WeiBalance]:
         return await_awaitable(self.get_balances_async(block=block))

--- a/y/prices/magic.py
+++ b/y/prices/magic.py
@@ -80,7 +80,7 @@ async def get_price_async(
 
     try:
         return await _get_price(token_address, block, fail_to_None=fail_to_None, silent=silent)
-    except (ContractNotFound, NonStandardERC20, RecursionError):
+    except (ContractNotFound, NonStandardERC20, RecursionError, PriceError):
         if fail_to_None:
             return None
         raise PriceError(f'could not fetch price for {await ERC20(token_address).symbol_async} {token_address} on {Network.printable()}')


### PR DESCRIPTION
## Description

- Remove `self.address` from `self.tokens_async()` in `balancer/v2.py`
- Add a try catch for `PriceError` for `get_price_async` in `balancer/balancer.py`, to handle when the magic fails within the call

## Motivation

The magic `get_price` hangs for address 0x652d486b80c461c397b0d95612a404da936f3db3 due to an infinite loop, triggered by recursively calling the magic `get_price` inside the call again