### PR TITLE
chore: bump a_sync

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ checksum_dict>=1.1.1
 dank_mids>=4.20.36,!=4.20.38
 eth-brownie>=1.18.1,<1.20
 eth_retry>=0.1.17,<0.2
-ez-a-sync>=0.1.5
+ez-a-sync>=0.1.7
 joblib>=1.0.1


### PR DESCRIPTION
This PR bumps the a_sync version to fix an edge case when running coroutines in subthreads