### PR TITLE
fix: suppress OptimisticCheckError when updating cache metadata

### DIFF
--- a/y/_db/utils/logs.py
+++ b/y/_db/utils/logs.py
@@ -1,10 +1,11 @@
 
 import logging
+from contextlib import suppress
 from typing import List, Optional
 
 from brownie.convert import EthAddress
 from msgspec import json
-from pony.orm import commit, db_session, select
+from pony.orm import OptimisticCheckError, commit, db_session, select
 from pony.orm.core import Query
 from web3.types import LogReceipt
 
@@ -80,30 +81,34 @@ class LogCache(DiskCache[LogReceipt, LogCacheInfo]):
     def _is_cached_thru(self, from_block: int) -> int:
         from y._db.utils import utils as db
         
-        if self.addresses:
-            chain = db.get_chain(sync=True)
-            infos: List[LogCacheInfo]
-            if isinstance(self.addresses, str):
-                infos = [
-                    # If we cached all logs for this address...
-                    LogCacheInfo.get(chain=chain, address=self.addresses, topics=json.encode(None))
-                    # ... or we cached all logs for these specific topics for this address
-                    or LogCacheInfo.get(chain=chain, address=self.addresses, topics=json.encode(self.topics))
-                ]
-            else:
-                infos = [
-                    # If we cached all logs for this address...
-                    LogCacheInfo.get(chain=chain, address=addr, topics=json.encode(None))
-                    # ... or we cached all logs for these specific topics for this address
-                    or LogCacheInfo.get(chain=chain, address=addr, topics=json.encode(self.topics))
-                    for addr in self.addresses
-                ]
-            if all(info and from_block >= info.cached_from for info in infos):
-                return min(info.cached_thru for info in infos)
-                
-        elif (info := self.load_metadata()) and from_block >= info.cached_from:
-            return info.cached_thru
-        return 0
+        while True:
+            try:
+                if self.addresses:
+                    chain = db.get_chain(sync=True)
+                    infos: List[LogCacheInfo]
+                    if isinstance(self.addresses, str):
+                        infos = [
+                            # If we cached all logs for this address...
+                            LogCacheInfo.get(chain=chain, address=self.addresses, topics=json.encode(None))
+                            # ... or we cached all logs for these specific topics for this address
+                            or LogCacheInfo.get(chain=chain, address=self.addresses, topics=json.encode(self.topics))
+                        ]
+                    else:
+                        infos = [
+                            # If we cached all logs for this address...
+                            LogCacheInfo.get(chain=chain, address=addr, topics=json.encode(None))
+                            # ... or we cached all logs for these specific topics for this address
+                            or LogCacheInfo.get(chain=chain, address=addr, topics=json.encode(self.topics))
+                            for addr in self.addresses
+                        ]
+                    if all(info and from_block >= info.cached_from for info in infos):
+                        return min(info.cached_thru for info in infos)
+                        
+                elif (info := self.load_metadata()) and from_block >= info.cached_from:
+                    return info.cached_thru
+                return 0
+            except OptimisticCheckError as e:
+                logger.debug("%s got exc %s when updating cache metadata, retrying...", self, e)
     
     def _select(self, from_block: int, to_block: int) -> List[LogReceipt]:
         return [json.decode(log.raw) for log in self._get_query(from_block, to_block)]


### PR DESCRIPTION
This was an intermittent error that would cause script failure even though it didn't impact lib logic. Now its suppressed.