### PR TITLE
fix: include inflection in deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ dank_mids>=4.20.86
 eth-brownie>=1.19.3,<1.21
 eth_retry>=0.1.19,<0.2
 ez-a-sync>=0.18.2,<0.20
+inflection>=0.1,<0.5
 joblib>=1.0.1
 multicall>=0.8.2
 pony


### PR DESCRIPTION
brownie 1.20 doesn't come with it