### PR TITLE
fix(docs): skip more useless members

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -112,8 +112,8 @@ def skip_specific_members(app, what, name, obj, skip, options):
     if type(getattr(obj, "__self__", None)).__qualname__ == "typing.NewType" and name in ["__init__", "__call__"]:
         return True
     
-    # Skip the __init__, args, and with_traceback members of all Exceptions
-    if issubclass(getattr(obj, '__objclass__', type), BaseException) and name in ["__init__", "args", "with_traceback"]:
+    # Skip the __init__, __new__, __str__, __getattribute__, args, and with_traceback members of all Exceptions
+    if issubclass(getattr(obj, '__objclass__', type), BaseException) and name in ["__init__", "__new__", "__str__", "__getattribute__", "args", "with_traceback"]:
         return True
     
     return skip

--- a/y/convert.py
+++ b/y/convert.py
@@ -11,7 +11,6 @@ def to_address(address: AnyAddressType) -> str:
     return brownie.convert.to_address(address)
 
 def _int_to_address(int_address: int) -> str:
-    suffix = HexBytes(int_address).hex()[2:]
-    padding = '0' * (40 - len(suffix))
-    address = '0x' + padding + suffix
-    return brownie.convert.to_address(address)
+    hex_value = HexBytes(int_address).hex()[2:]
+    padding = '0' * (40 - len(hex_value))
+    return brownie.convert.to_address(f'0x{padding}{hex_value}')


### PR DESCRIPTION
hide __new__, __str__, __getattribute__ members for Exception subclasses 