### PR TITLE
fix: Log response size exceeded

### DIFF
--- a/y/utils/events.py
+++ b/y/utils/events.py
@@ -360,6 +360,7 @@ def _get_logs_no_cache(
             "request timed out",
             "parse error",
             "method handler crashed",
+            "Log response size exceeded.",
         ]
         if any(err in str(e) for err in errs):
             logger.debug('your node is having trouble, breaking batch in half')


### PR DESCRIPTION
if batch size was too big, split and try again