### PR TITLE
feat: shrink db threadpool size when using sqlite backend

### DIFF
--- a/build/__native_e48b665766e5f62102a4.c
+++ b/build/__native_e48b665766e5f62102a4.c
@@ -1327,7 +1327,7 @@ PyObject *CPyDef_decorators___retry_locked_wrap_retry_locked_obj_____call__(PyOb
     PyObject *cpy_r_r88;
     cpy_r_r0 = ((y____db___decorators___retry_locked_wrap_retry_locked_objObject *)cpy_r___mypyc_self__)->___mypyc_env__;
     if (unlikely(cpy_r_r0 == NULL)) {
-        CPy_AttributeError("y/_db/decorators.py", "retry_locked_wrap", "retry_locked_wrap_retry_locked_obj", "__mypyc_env__", 58, CPyStatic_decorators___globals);
+        CPy_AttributeError("y/_db/decorators.py", "retry_locked_wrap", "retry_locked_wrap_retry_locked_obj", "__mypyc_env__", 64, CPyStatic_decorators___globals);
         goto CPyL64;
     }
     CPy_INCREF_NO_IMM(cpy_r_r0);
@@ -1337,38 +1337,38 @@ CPyL2: ;
     if (!1) goto CPyL65;
     cpy_r_r1 = ((y____db___decorators___retry_locked_envObject *)cpy_r_r0)->_callable;
     if (unlikely(cpy_r_r1 == NULL)) {
-        CPy_AttributeError("y/_db/decorators.py", "retry_locked_wrap", "retry_locked_env", "callable", 62, CPyStatic_decorators___globals);
+        CPy_AttributeError("y/_db/decorators.py", "retry_locked_wrap", "retry_locked_env", "callable", 68, CPyStatic_decorators___globals);
         goto CPyL13;
     }
     CPy_INCREF(cpy_r_r1);
 CPyL4: ;
     cpy_r_r2 = PyList_New(0);
     if (unlikely(cpy_r_r2 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 62, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 68, CPyStatic_decorators___globals);
         goto CPyL66;
     }
     cpy_r_r3 = CPyList_Extend(cpy_r_r2, cpy_r_args);
     if (unlikely(cpy_r_r3 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 62, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 68, CPyStatic_decorators___globals);
         goto CPyL67;
     } else
         goto CPyL68;
 CPyL6: ;
     cpy_r_r4 = PyDict_New();
     if (unlikely(cpy_r_r4 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 62, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 68, CPyStatic_decorators___globals);
         goto CPyL67;
     }
     cpy_r_r5 = CPyDict_UpdateInDisplay(cpy_r_r4, cpy_r_kwargs);
     cpy_r_r6 = cpy_r_r5 >= 0;
     if (unlikely(!cpy_r_r6)) {
-        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 62, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 68, CPyStatic_decorators___globals);
         goto CPyL69;
     }
     cpy_r_r7 = PyList_AsTuple(cpy_r_r2);
     CPy_DECREF_NO_IMM(cpy_r_r2);
     if (unlikely(cpy_r_r7 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 62, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 68, CPyStatic_decorators___globals);
         goto CPyL70;
     }
     cpy_r_r8 = PyObject_Call(cpy_r_r1, cpy_r_r7, cpy_r_r4);
@@ -1376,20 +1376,20 @@ CPyL6: ;
     CPy_DECREF(cpy_r_r7);
     CPy_DECREF(cpy_r_r4);
     if (unlikely(cpy_r_r8 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 62, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 68, CPyStatic_decorators___globals);
         goto CPyL13;
     }
     cpy_r_r9 = CPyStatic_decorators___globals;
     cpy_r_r10 = CPyStatics[3]; /* 'commit' */
     cpy_r_r11 = CPyDict_GetItem(cpy_r_r9, cpy_r_r10);
     if (unlikely(cpy_r_r11 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 63, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 69, CPyStatic_decorators___globals);
         goto CPyL71;
     }
     cpy_r_r12 = PyObject_Vectorcall(cpy_r_r11, 0, 0, 0);
     CPy_DECREF(cpy_r_r11);
     if (unlikely(cpy_r_r12 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 63, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 69, CPyStatic_decorators___globals);
         goto CPyL71;
     } else
         goto CPyL72;
@@ -1401,21 +1401,21 @@ CPyL13: ;
     cpy_r_r15 = CPyStatics[4]; /* 'CommitException' */
     cpy_r_r16 = CPyDict_GetItem(cpy_r_r14, cpy_r_r15);
     if (unlikely(cpy_r_r16 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 65, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 71, CPyStatic_decorators___globals);
         goto CPyL73;
     }
     cpy_r_r17 = CPyStatic_decorators___globals;
     cpy_r_r18 = CPyStatics[5]; /* 'OperationalError' */
     cpy_r_r19 = CPyDict_GetItem(cpy_r_r17, cpy_r_r18);
     if (unlikely(cpy_r_r19 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 65, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 71, CPyStatic_decorators___globals);
         goto CPyL74;
     }
     cpy_r_r20 = CPyStatic_decorators___globals;
     cpy_r_r21 = CPyStatics[6]; /* 'UnexpectedError' */
     cpy_r_r22 = CPyDict_GetItem(cpy_r_r20, cpy_r_r21);
     if (unlikely(cpy_r_r22 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 65, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 71, CPyStatic_decorators___globals);
         goto CPyL75;
     }
     cpy_r_r23.f0 = cpy_r_r16;
@@ -1446,7 +1446,7 @@ CPyL19: ;
     PyErr_SetString(PyExc_NameError, "value for final name \"log_warning\" was not set");
     cpy_r_r29 = 0;
     if (unlikely(!cpy_r_r29)) {
-        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 66, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 72, CPyStatic_decorators___globals);
         goto CPyL61;
     } else
         goto CPyL77;
@@ -1466,7 +1466,7 @@ CPyL23: ;
     PyErr_SetString(PyExc_NameError, "value for final name \"log_debug\" was not set");
     cpy_r_r32 = 0;
     if (unlikely(!cpy_r_r32)) {
-        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 66, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 72, CPyStatic_decorators___globals);
         goto CPyL61;
     } else
         goto CPyL79;
@@ -1479,14 +1479,14 @@ CPyL26: ;
     cpy_r_log = cpy_r_r30;
     cpy_r_r33 = PyObject_Str(cpy_r_e);
     if (unlikely(cpy_r_r33 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 67, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 73, CPyStatic_decorators___globals);
         goto CPyL80;
     }
     cpy_r_stre = cpy_r_r33;
     cpy_r_r34 = CPyStatics[7]; /* '%s.%s got %s: %s' */
     cpy_r_r35 = ((y____db___decorators___retry_locked_envObject *)cpy_r_r0)->_callable;
     if (unlikely(cpy_r_r35 == NULL)) {
-        CPy_AttributeError("y/_db/decorators.py", "retry_locked_wrap", "retry_locked_env", "callable", 68, CPyStatic_decorators___globals);
+        CPy_AttributeError("y/_db/decorators.py", "retry_locked_wrap", "retry_locked_env", "callable", 74, CPyStatic_decorators___globals);
         goto CPyL81;
     }
     CPy_INCREF(cpy_r_r35);
@@ -1495,18 +1495,18 @@ CPyL28: ;
     cpy_r_r37 = CPyObject_GetAttr(cpy_r_r35, cpy_r_r36);
     CPy_DecRef(cpy_r_r35);
     if (unlikely(cpy_r_r37 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 68, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 74, CPyStatic_decorators___globals);
         goto CPyL81;
     }
     if (likely(PyUnicode_Check(cpy_r_r37)))
         cpy_r_r38 = cpy_r_r37;
     else {
-        CPy_TypeErrorTraceback("y/_db/decorators.py", "retry_locked_wrap", 68, CPyStatic_decorators___globals, "str", cpy_r_r37);
+        CPy_TypeErrorTraceback("y/_db/decorators.py", "retry_locked_wrap", 74, CPyStatic_decorators___globals, "str", cpy_r_r37);
         goto CPyL81;
     }
     cpy_r_r39 = ((y____db___decorators___retry_locked_envObject *)cpy_r_r0)->_callable;
     if (unlikely(cpy_r_r39 == NULL)) {
-        CPy_AttributeError("y/_db/decorators.py", "retry_locked_wrap", "retry_locked_env", "callable", 68, CPyStatic_decorators___globals);
+        CPy_AttributeError("y/_db/decorators.py", "retry_locked_wrap", "retry_locked_env", "callable", 74, CPyStatic_decorators___globals);
         goto CPyL82;
     }
     CPy_INCREF(cpy_r_r39);
@@ -1515,13 +1515,13 @@ CPyL31: ;
     cpy_r_r41 = CPyObject_GetAttr(cpy_r_r39, cpy_r_r40);
     CPy_DecRef(cpy_r_r39);
     if (unlikely(cpy_r_r41 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 68, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 74, CPyStatic_decorators___globals);
         goto CPyL82;
     }
     if (likely(PyUnicode_Check(cpy_r_r41)))
         cpy_r_r42 = cpy_r_r41;
     else {
-        CPy_TypeErrorTraceback("y/_db/decorators.py", "retry_locked_wrap", 68, CPyStatic_decorators___globals, "str", cpy_r_r41);
+        CPy_TypeErrorTraceback("y/_db/decorators.py", "retry_locked_wrap", 74, CPyStatic_decorators___globals, "str", cpy_r_r41);
         goto CPyL82;
     }
     cpy_r_r43 = PyObject_Type(cpy_r_e);
@@ -1531,7 +1531,7 @@ CPyL31: ;
     cpy_r_r46 = PyObject_Vectorcall(cpy_r_log, cpy_r_r45, 5, 0);
     CPy_DecRef(cpy_r_log);
     if (unlikely(cpy_r_r46 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 68, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 74, CPyStatic_decorators___globals);
         goto CPyL83;
     } else
         goto CPyL84;
@@ -1544,7 +1544,7 @@ CPyL34: ;
     CPy_DecRef(cpy_r_stre);
     cpy_r_r49 = cpy_r_r48 >= 0;
     if (unlikely(!cpy_r_r49)) {
-        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 69, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 75, CPyStatic_decorators___globals);
         goto CPyL73;
     }
     cpy_r_r50 = cpy_r_r48;
@@ -1566,7 +1566,7 @@ CPyL38: ;
     cpy_r_r53 = CPyStatics[11]; /* 'sleep' */
     cpy_r_r54 = CPyObject_GetAttr(cpy_r_r52, cpy_r_r53);
     if (unlikely(cpy_r_r54 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 71, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 77, CPyStatic_decorators___globals);
         goto CPyL73;
     }
     cpy_r_r55 = PyFloat_FromDouble(cpy_r_sleep);
@@ -1575,7 +1575,7 @@ CPyL38: ;
     cpy_r_r58 = PyObject_Vectorcall(cpy_r_r54, cpy_r_r57, 1, 0);
     CPy_DecRef(cpy_r_r54);
     if (unlikely(cpy_r_r58 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 71, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 77, CPyStatic_decorators___globals);
         goto CPyL87;
     } else
         goto CPyL88;
@@ -1589,7 +1589,7 @@ CPyL41: ;
     cpy_r_r61 = CPyStatics[12]; /* 'TransactionError' */
     cpy_r_r62 = CPyDict_GetItem(cpy_r_r60, cpy_r_r61);
     if (unlikely(cpy_r_r62 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 73, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 79, CPyStatic_decorators___globals);
         goto CPyL73;
     }
     cpy_r_r63 = CPy_ExceptionMatches(cpy_r_r62);
@@ -1599,14 +1599,14 @@ CPyL41: ;
     cpy_r_e = cpy_r_r64;
     cpy_r_r65 = PyObject_Str(cpy_r_e);
     if (unlikely(cpy_r_r65 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 74, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 80, CPyStatic_decorators___globals);
         goto CPyL90;
     }
     cpy_r_stre = cpy_r_r65;
     cpy_r_r66 = CPyStatics[7]; /* '%s.%s got %s: %s' */
     cpy_r_r67 = ((y____db___decorators___retry_locked_envObject *)cpy_r_r0)->_callable;
     if (unlikely(cpy_r_r67 == NULL)) {
-        CPy_AttributeError("y/_db/decorators.py", "retry_locked_wrap", "retry_locked_env", "callable", 75, CPyStatic_decorators___globals);
+        CPy_AttributeError("y/_db/decorators.py", "retry_locked_wrap", "retry_locked_env", "callable", 81, CPyStatic_decorators___globals);
         goto CPyL91;
     }
     CPy_INCREF(cpy_r_r67);
@@ -1615,18 +1615,18 @@ CPyL45: ;
     cpy_r_r69 = CPyObject_GetAttr(cpy_r_r67, cpy_r_r68);
     CPy_DecRef(cpy_r_r67);
     if (unlikely(cpy_r_r69 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 75, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 81, CPyStatic_decorators___globals);
         goto CPyL91;
     }
     if (likely(PyUnicode_Check(cpy_r_r69)))
         cpy_r_r70 = cpy_r_r69;
     else {
-        CPy_TypeErrorTraceback("y/_db/decorators.py", "retry_locked_wrap", 75, CPyStatic_decorators___globals, "str", cpy_r_r69);
+        CPy_TypeErrorTraceback("y/_db/decorators.py", "retry_locked_wrap", 81, CPyStatic_decorators___globals, "str", cpy_r_r69);
         goto CPyL91;
     }
     cpy_r_r71 = ((y____db___decorators___retry_locked_envObject *)cpy_r_r0)->_callable;
     if (unlikely(cpy_r_r71 == NULL)) {
-        CPy_AttributeError("y/_db/decorators.py", "retry_locked_wrap", "retry_locked_env", "callable", 75, CPyStatic_decorators___globals);
+        CPy_AttributeError("y/_db/decorators.py", "retry_locked_wrap", "retry_locked_env", "callable", 81, CPyStatic_decorators___globals);
         goto CPyL92;
     }
     CPy_INCREF(cpy_r_r71);
@@ -1635,13 +1635,13 @@ CPyL48: ;
     cpy_r_r73 = CPyObject_GetAttr(cpy_r_r71, cpy_r_r72);
     CPy_DecRef(cpy_r_r71);
     if (unlikely(cpy_r_r73 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 75, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 81, CPyStatic_decorators___globals);
         goto CPyL92;
     }
     if (likely(PyUnicode_Check(cpy_r_r73)))
         cpy_r_r74 = cpy_r_r73;
     else {
-        CPy_TypeErrorTraceback("y/_db/decorators.py", "retry_locked_wrap", 75, CPyStatic_decorators___globals, "str", cpy_r_r73);
+        CPy_TypeErrorTraceback("y/_db/decorators.py", "retry_locked_wrap", 81, CPyStatic_decorators___globals, "str", cpy_r_r73);
         goto CPyL92;
     }
     cpy_r_r75 = PyObject_Type(cpy_r_e);
@@ -1655,7 +1655,7 @@ CPyL51: ;
     PyErr_SetString(PyExc_NameError, "value for final name \"log_debug\" was not set");
     cpy_r_r77 = 0;
     if (unlikely(!cpy_r_r77)) {
-        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 75, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 81, CPyStatic_decorators___globals);
         goto CPyL61;
     } else
         goto CPyL94;
@@ -1666,7 +1666,7 @@ CPyL53: ;
     cpy_r_r79 = (PyObject **)&cpy_r_r78;
     cpy_r_r80 = PyObject_Vectorcall(cpy_r_r76, cpy_r_r79, 5, 0);
     if (unlikely(cpy_r_r80 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 75, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 81, CPyStatic_decorators___globals);
         goto CPyL95;
     } else
         goto CPyL96;
@@ -1680,7 +1680,7 @@ CPyL54: ;
     CPy_DecRef(cpy_r_stre);
     cpy_r_r83 = cpy_r_r82 >= 0;
     if (unlikely(!cpy_r_r83)) {
-        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 76, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 82, CPyStatic_decorators___globals);
         goto CPyL73;
     }
     cpy_r_r84 = cpy_r_r82;
@@ -1901,7 +1901,7 @@ PyObject *CPyPy_decorators___retry_locked_wrap_retry_locked_obj_____call__(PyObj
 fail: ;
     CPy_DECREF(obj_args);
     CPy_DECREF(obj_kwargs);
-    CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 58, CPyStatic_decorators___globals);
+    CPy_AddTraceback("y/_db/decorators.py", "retry_locked_wrap", 64, CPyStatic_decorators___globals);
     return NULL;
 }
 
@@ -1925,7 +1925,7 @@ PyObject *CPyDef_decorators___retry_locked(PyObject *cpy_r_callable) {
     PyObject *cpy_r_r18;
     cpy_r_r0 = CPyDef_decorators___retry_locked_env();
     if (unlikely(cpy_r_r0 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "retry_locked", 33, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "retry_locked", 39, CPyStatic_decorators___globals);
         goto CPyL10;
     }
     CPy_INCREF(cpy_r_callable);
@@ -1935,12 +1935,12 @@ PyObject *CPyDef_decorators___retry_locked(PyObject *cpy_r_callable) {
     ((y____db___decorators___retry_locked_envObject *)cpy_r_r0)->_callable = cpy_r_callable;
     cpy_r_r1 = 1;
     if (unlikely(!cpy_r_r1)) {
-        CPy_AddTraceback("y/_db/decorators.py", "retry_locked", 33, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "retry_locked", 39, CPyStatic_decorators___globals);
         goto CPyL11;
     }
     cpy_r_r2 = CPyDef_decorators___retry_locked_wrap_retry_locked_obj();
     if (unlikely(cpy_r_r2 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "retry_locked", 58, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "retry_locked", 64, CPyStatic_decorators___globals);
         goto CPyL11;
     }
     CPy_INCREF_NO_IMM(cpy_r_r0);
@@ -1950,7 +1950,7 @@ PyObject *CPyDef_decorators___retry_locked(PyObject *cpy_r_callable) {
     ((y____db___decorators___retry_locked_wrap_retry_locked_objObject *)cpy_r_r2)->___mypyc_env__ = cpy_r_r0;
     cpy_r_r3 = 1;
     if (unlikely(!cpy_r_r3)) {
-        CPy_AddTraceback("y/_db/decorators.py", "retry_locked", 58, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "retry_locked", 64, CPyStatic_decorators___globals);
         goto CPyL12;
     }
     cpy_r_r4 = ((y____db___decorators___retry_locked_envObject *)cpy_r_r0)->_callable;
@@ -1961,7 +1961,7 @@ PyObject *CPyDef_decorators___retry_locked(PyObject *cpy_r_callable) {
     }
     CPy_DECREF_NO_IMM(cpy_r_r0);
     if (unlikely(cpy_r_r4 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "retry_locked", 57, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "retry_locked", 63, CPyStatic_decorators___globals);
         goto CPyL13;
     }
 CPyL5: ;
@@ -1969,7 +1969,7 @@ CPyL5: ;
     cpy_r_r6 = CPyStatics[14]; /* 'wraps' */
     cpy_r_r7 = CPyDict_GetItem(cpy_r_r5, cpy_r_r6);
     if (unlikely(cpy_r_r7 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "retry_locked", 57, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "retry_locked", 63, CPyStatic_decorators___globals);
         goto CPyL14;
     }
     PyObject *cpy_r_r8[1] = {cpy_r_r4};
@@ -1977,7 +1977,7 @@ CPyL5: ;
     cpy_r_r10 = PyObject_Vectorcall(cpy_r_r7, cpy_r_r9, 1, 0);
     CPy_DECREF(cpy_r_r7);
     if (unlikely(cpy_r_r10 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "retry_locked", 57, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "retry_locked", 63, CPyStatic_decorators___globals);
         goto CPyL14;
     }
     CPy_DECREF(cpy_r_r4);
@@ -1986,7 +1986,7 @@ CPyL5: ;
     cpy_r_r13 = PyObject_Vectorcall(cpy_r_r10, cpy_r_r12, 1, 0);
     CPy_DECREF(cpy_r_r10);
     if (unlikely(cpy_r_r13 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "retry_locked", 58, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "retry_locked", 64, CPyStatic_decorators___globals);
         goto CPyL13;
     }
     CPy_DECREF_NO_IMM(cpy_r_r2);
@@ -1997,7 +1997,7 @@ CPyL5: ;
     CPy_DECREF(cpy_r_r13);
     cpy_r_r17 = cpy_r_r16 >= 0;
     if (unlikely(!cpy_r_r17)) {
-        CPy_AddTraceback("y/_db/decorators.py", "retry_locked", 58, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "retry_locked", 64, CPyStatic_decorators___globals);
         goto CPyL15;
     }
     return cpy_r_r13;
@@ -2034,7 +2034,7 @@ PyObject *CPyPy_decorators___retry_locked(PyObject *self, PyObject *const *args,
     PyObject *retval = CPyDef_decorators___retry_locked(arg_callable);
     return retval;
 fail: ;
-    CPy_AddTraceback("y/_db/decorators.py", "retry_locked", 33, CPyStatic_decorators___globals);
+    CPy_AddTraceback("y/_db/decorators.py", "retry_locked", 39, CPyStatic_decorators___globals);
     return NULL;
 }
 
@@ -2087,14 +2087,14 @@ PyObject *CPyDef_decorators_____mypyc_lambda__0_obj_____call__(PyObject *cpy_r__
     PyObject *cpy_r_r8;
     cpy_r_r0 = CPyDef_decorators___retry_locked(cpy_r_func);
     if (unlikely(cpy_r_r0 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<lambda>", 82, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "<lambda>", 88, CPyStatic_decorators___globals);
         goto CPyL5;
     }
     cpy_r_r1 = CPyStatic_decorators___globals;
     cpy_r_r2 = CPyStatics[16]; /* 'db_session' */
     cpy_r_r3 = CPyDict_GetItem(cpy_r_r1, cpy_r_r2);
     if (unlikely(cpy_r_r3 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<lambda>", 82, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "<lambda>", 88, CPyStatic_decorators___globals);
         goto CPyL6;
     }
     PyObject *cpy_r_r4[1] = {cpy_r_r0};
@@ -2102,14 +2102,14 @@ PyObject *CPyDef_decorators_____mypyc_lambda__0_obj_____call__(PyObject *cpy_r__
     cpy_r_r6 = PyObject_Vectorcall(cpy_r_r3, cpy_r_r5, 1, 0);
     CPy_DECREF(cpy_r_r3);
     if (unlikely(cpy_r_r6 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<lambda>", 82, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "<lambda>", 88, CPyStatic_decorators___globals);
         goto CPyL6;
     }
     CPy_DECREF(cpy_r_r0);
     cpy_r_r7 = CPyDef_decorators___retry_locked(cpy_r_r6);
     CPy_DECREF(cpy_r_r6);
     if (unlikely(cpy_r_r7 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<lambda>", 82, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "<lambda>", 88, CPyStatic_decorators___globals);
         goto CPyL5;
     }
     return cpy_r_r7;
@@ -2134,7 +2134,7 @@ PyObject *CPyPy_decorators_____mypyc_lambda__0_obj_____call__(PyObject *self, Py
     PyObject *retval = CPyDef_decorators_____mypyc_lambda__0_obj_____call__(arg___mypyc_self__, arg_func);
     return retval;
 fail: ;
-    CPy_AddTraceback("y/_db/decorators.py", "<lambda>", 82, CPyStatic_decorators___globals);
+    CPy_AddTraceback("y/_db/decorators.py", "<lambda>", 88, CPyStatic_decorators___globals);
     return NULL;
 }
 
@@ -2199,7 +2199,7 @@ PyObject *CPyDef_decorators_____mypyc_lambda__1_obj_____call__(PyObject *cpy_r__
     PyErr_SetString(PyExc_NameError, "value for final name \"ydb_read_threads\" was not set");
     cpy_r_r2 = 0;
     if (unlikely(!cpy_r_r2)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<lambda>", 85, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "<lambda>", 91, CPyStatic_decorators___globals);
         goto CPyL11;
     }
     CPy_Unreachable();
@@ -2208,16 +2208,16 @@ CPyL3: ;
     cpy_r_r4 = CPyStatics[18]; /* 'a_sync' */
     cpy_r_r5 = CPyDict_GetItem(cpy_r_r3, cpy_r_r4);
     if (unlikely(cpy_r_r5 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<lambda>", 85, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "<lambda>", 91, CPyStatic_decorators___globals);
         goto CPyL11;
     }
     PyObject *cpy_r_r6[2] = {cpy_r_r0, cpy_r_r1};
     cpy_r_r7 = (PyObject **)&cpy_r_r6;
-    cpy_r_r8 = CPyStatics[488]; /* ('default', 'executor') */
+    cpy_r_r8 = CPyStatics[489]; /* ('default', 'executor') */
     cpy_r_r9 = PyObject_Vectorcall(cpy_r_r5, cpy_r_r7, 0, cpy_r_r8);
     CPy_DECREF(cpy_r_r5);
     if (unlikely(cpy_r_r9 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<lambda>", 85, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "<lambda>", 91, CPyStatic_decorators___globals);
         goto CPyL11;
     }
     cpy_r_r10 = CPyStatic_decorators___db_session_retry_locked;
@@ -2229,7 +2229,7 @@ CPyL6: ;
     PyErr_SetString(PyExc_NameError, "value for final name \"db_session_retry_locked\" was not set");
     cpy_r_r11 = 0;
     if (unlikely(!cpy_r_r11)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<lambda>", 85, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "<lambda>", 91, CPyStatic_decorators___globals);
         goto CPyL11;
     }
     CPy_Unreachable();
@@ -2238,7 +2238,7 @@ CPyL8: ;
     cpy_r_r13 = (PyObject **)&cpy_r_r12;
     cpy_r_r14 = PyObject_Vectorcall(cpy_r_r10, cpy_r_r13, 1, 0);
     if (unlikely(cpy_r_r14 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<lambda>", 85, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "<lambda>", 91, CPyStatic_decorators___globals);
         goto CPyL13;
     }
     PyObject *cpy_r_r15[1] = {cpy_r_r14};
@@ -2246,7 +2246,7 @@ CPyL8: ;
     cpy_r_r17 = PyObject_Vectorcall(cpy_r_r9, cpy_r_r16, 1, 0);
     CPy_DECREF(cpy_r_r9);
     if (unlikely(cpy_r_r17 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<lambda>", 85, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "<lambda>", 91, CPyStatic_decorators___globals);
         goto CPyL14;
     }
     CPy_DECREF(cpy_r_r14);
@@ -2278,7 +2278,7 @@ PyObject *CPyPy_decorators_____mypyc_lambda__1_obj_____call__(PyObject *self, Py
     PyObject *retval = CPyDef_decorators_____mypyc_lambda__1_obj_____call__(arg___mypyc_self__, arg_fn);
     return retval;
 fail: ;
-    CPy_AddTraceback("y/_db/decorators.py", "<lambda>", 85, CPyStatic_decorators___globals);
+    CPy_AddTraceback("y/_db/decorators.py", "<lambda>", 91, CPyStatic_decorators___globals);
     return NULL;
 }
 
@@ -2342,29 +2342,29 @@ PyObject *CPyDef_decorators_____mypyc_lambda__2_obj_____call__(PyObject *cpy_r__
     cpy_r_r1 = CPyStatics[21]; /* 'lru_cache' */
     cpy_r_r2 = CPyDict_GetItem(cpy_r_r0, cpy_r_r1);
     if (unlikely(cpy_r_r2 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<lambda>", 111, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "<lambda>", 117, CPyStatic_decorators___globals);
         goto CPyL8;
     }
     cpy_r_r3 = Py_None;
     PyObject *cpy_r_r4[1] = {cpy_r_r3};
     cpy_r_r5 = (PyObject **)&cpy_r_r4;
-    cpy_r_r6 = CPyStatics[489]; /* ('maxsize',) */
+    cpy_r_r6 = CPyStatics[490]; /* ('maxsize',) */
     cpy_r_r7 = PyObject_Vectorcall(cpy_r_r2, cpy_r_r5, 0, cpy_r_r6);
     CPy_DECREF(cpy_r_r2);
     if (unlikely(cpy_r_r7 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<lambda>", 111, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "<lambda>", 117, CPyStatic_decorators___globals);
         goto CPyL8;
     }
     cpy_r_r8 = CPyDef_decorators___retry_locked(cpy_r_func);
     if (unlikely(cpy_r_r8 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<lambda>", 111, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "<lambda>", 117, CPyStatic_decorators___globals);
         goto CPyL9;
     }
     cpy_r_r9 = CPyStatic_decorators___globals;
     cpy_r_r10 = CPyStatics[16]; /* 'db_session' */
     cpy_r_r11 = CPyDict_GetItem(cpy_r_r9, cpy_r_r10);
     if (unlikely(cpy_r_r11 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<lambda>", 111, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "<lambda>", 117, CPyStatic_decorators___globals);
         goto CPyL10;
     }
     PyObject *cpy_r_r12[1] = {cpy_r_r8};
@@ -2372,7 +2372,7 @@ PyObject *CPyDef_decorators_____mypyc_lambda__2_obj_____call__(PyObject *cpy_r__
     cpy_r_r14 = PyObject_Vectorcall(cpy_r_r11, cpy_r_r13, 1, 0);
     CPy_DECREF(cpy_r_r11);
     if (unlikely(cpy_r_r14 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<lambda>", 111, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "<lambda>", 117, CPyStatic_decorators___globals);
         goto CPyL10;
     }
     CPy_DECREF(cpy_r_r8);
@@ -2381,14 +2381,14 @@ PyObject *CPyDef_decorators_____mypyc_lambda__2_obj_____call__(PyObject *cpy_r__
     cpy_r_r17 = PyObject_Vectorcall(cpy_r_r7, cpy_r_r16, 1, 0);
     CPy_DECREF(cpy_r_r7);
     if (unlikely(cpy_r_r17 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<lambda>", 111, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "<lambda>", 117, CPyStatic_decorators___globals);
         goto CPyL11;
     }
     CPy_DECREF(cpy_r_r14);
     cpy_r_r18 = CPyDef_decorators___retry_locked(cpy_r_r17);
     CPy_DECREF(cpy_r_r17);
     if (unlikely(cpy_r_r18 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<lambda>", 110, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "<lambda>", 116, CPyStatic_decorators___globals);
         goto CPyL8;
     }
     return cpy_r_r18;
@@ -2420,7 +2420,7 @@ PyObject *CPyPy_decorators_____mypyc_lambda__2_obj_____call__(PyObject *self, Py
     PyObject *retval = CPyDef_decorators_____mypyc_lambda__2_obj_____call__(arg___mypyc_self__, arg_func);
     return retval;
 fail: ;
-    CPy_AddTraceback("y/_db/decorators.py", "<lambda>", 110, CPyStatic_decorators___globals);
+    CPy_AddTraceback("y/_db/decorators.py", "<lambda>", 116, CPyStatic_decorators___globals);
     return NULL;
 }
 
@@ -2525,14 +2525,14 @@ PyObject *CPyDef_decorators___result_count_wrap_log_result_count_result_count_de
     PyObject *cpy_r_r62;
     cpy_r_r0 = ((y____db___decorators___result_count_wrap_log_result_count_result_count_deco_objObject *)cpy_r___mypyc_self__)->___mypyc_env__;
     if (unlikely(cpy_r_r0 == NULL)) {
-        CPy_AttributeError("y/_db/decorators.py", "result_count_wrap", "result_count_wrap_log_result_count_result_count_deco_obj", "__mypyc_env__", 147, CPyStatic_decorators___globals);
+        CPy_AttributeError("y/_db/decorators.py", "result_count_wrap", "result_count_wrap_log_result_count_result_count_deco_obj", "__mypyc_env__", 153, CPyStatic_decorators___globals);
         goto CPyL45;
     }
     CPy_INCREF_NO_IMM(cpy_r_r0);
 CPyL1: ;
     cpy_r_r1 = ((y____db___decorators___result_count_deco_log_result_count_envObject *)cpy_r_r0)->___mypyc_env__;
     if (unlikely(cpy_r_r1 == NULL)) {
-        CPy_AttributeError("y/_db/decorators.py", "result_count_wrap", "result_count_deco_log_result_count_env", "__mypyc_env__", 147, CPyStatic_decorators___globals);
+        CPy_AttributeError("y/_db/decorators.py", "result_count_wrap", "result_count_deco_log_result_count_env", "__mypyc_env__", 153, CPyStatic_decorators___globals);
         goto CPyL46;
     }
     CPy_INCREF_NO_IMM(cpy_r_r1);
@@ -2545,37 +2545,37 @@ CPyL2: ;
     }
     CPy_DECREF_NO_IMM(cpy_r_r0);
     if (unlikely(cpy_r_r2 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 148, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 154, CPyStatic_decorators___globals);
         goto CPyL47;
     }
 CPyL3: ;
     cpy_r_r3 = PyList_New(0);
     if (unlikely(cpy_r_r3 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 148, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 154, CPyStatic_decorators___globals);
         goto CPyL48;
     }
     cpy_r_r4 = CPyList_Extend(cpy_r_r3, cpy_r_args);
     if (unlikely(cpy_r_r4 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 148, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 154, CPyStatic_decorators___globals);
         goto CPyL49;
     } else
         goto CPyL50;
 CPyL5: ;
     cpy_r_r5 = PyDict_New();
     if (unlikely(cpy_r_r5 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 148, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 154, CPyStatic_decorators___globals);
         goto CPyL49;
     }
     cpy_r_r6 = CPyDict_UpdateInDisplay(cpy_r_r5, cpy_r_kwargs);
     cpy_r_r7 = cpy_r_r6 >= 0;
     if (unlikely(!cpy_r_r7)) {
-        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 148, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 154, CPyStatic_decorators___globals);
         goto CPyL51;
     }
     cpy_r_r8 = PyList_AsTuple(cpy_r_r3);
     CPy_DECREF_NO_IMM(cpy_r_r3);
     if (unlikely(cpy_r_r8 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 148, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 154, CPyStatic_decorators___globals);
         goto CPyL52;
     }
     cpy_r_r9 = PyObject_Call(cpy_r_r2, cpy_r_r8, cpy_r_r5);
@@ -2583,7 +2583,7 @@ CPyL5: ;
     CPy_DECREF(cpy_r_r8);
     CPy_DECREF(cpy_r_r5);
     if (unlikely(cpy_r_r9 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 148, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 154, CPyStatic_decorators___globals);
         goto CPyL47;
     }
     cpy_r_r10 = CPyStatic_decorators___DEBUG;
@@ -2595,7 +2595,7 @@ CPyL10: ;
     PyErr_SetString(PyExc_NameError, "value for final name \"DEBUG\" was not set");
     cpy_r_r11 = 0;
     if (unlikely(!cpy_r_r11)) {
-        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 149, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 155, CPyStatic_decorators___globals);
         goto CPyL45;
     }
     CPy_Unreachable();
@@ -2609,7 +2609,7 @@ CPyL13: ;
     PyErr_SetString(PyExc_NameError, "value for final name \"_result_count_logger_is_enabled_for\" was not set");
     cpy_r_r13 = 0;
     if (unlikely(!cpy_r_r13)) {
-        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 149, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 155, CPyStatic_decorators___globals);
         goto CPyL45;
     }
     CPy_Unreachable();
@@ -2620,7 +2620,7 @@ CPyL15: ;
     cpy_r_r16 = (PyObject **)&cpy_r_r15;
     cpy_r_r17 = PyObject_Vectorcall(cpy_r_r12, cpy_r_r16, 1, 0);
     if (unlikely(cpy_r_r17 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 149, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 155, CPyStatic_decorators___globals);
         goto CPyL55;
     }
     CPy_DECREF(cpy_r_r14);
@@ -2630,7 +2630,7 @@ CPyL15: ;
         cpy_r_r18 = cpy_r_r17 == Py_True;
     CPy_DECREF(cpy_r_r17);
     if (unlikely(cpy_r_r18 == 2)) {
-        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 149, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 155, CPyStatic_decorators___globals);
         goto CPyL56;
     }
     if (!cpy_r_r18) goto CPyL57;
@@ -2644,14 +2644,14 @@ CPyL19: ;
     PyErr_SetString(PyExc_NameError, "value for final name \"_CHAIN_INFO\" was not set");
     cpy_r_r21 = 0;
     if (unlikely(!cpy_r_r21)) {
-        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 150, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 156, CPyStatic_decorators___globals);
         goto CPyL45;
     }
     CPy_Unreachable();
 CPyL21: ;
     cpy_r_r22 = ((y____db___decorators___log_result_count_envObject *)cpy_r_r1)->_arg_names;
     if (unlikely(cpy_r_r22 == NULL)) {
-        CPy_AttributeError("y/_db/decorators.py", "result_count_wrap", "log_result_count_env", "arg_names", 150, CPyStatic_decorators___globals);
+        CPy_AttributeError("y/_db/decorators.py", "result_count_wrap", "log_result_count_env", "arg_names", 156, CPyStatic_decorators___globals);
         goto CPyL56;
     }
     CPy_INCREF(cpy_r_r22);
@@ -2660,7 +2660,7 @@ CPyL22: ;
     cpy_r_r24 = CPyStatics[24]; /* 'zip' */
     cpy_r_r25 = CPyObject_GetAttr(cpy_r_r23, cpy_r_r24);
     if (unlikely(cpy_r_r25 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 150, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 156, CPyStatic_decorators___globals);
         goto CPyL59;
     }
     PyObject *cpy_r_r26[2] = {cpy_r_r22, cpy_r_args};
@@ -2668,13 +2668,13 @@ CPyL22: ;
     cpy_r_r28 = PyObject_Vectorcall(cpy_r_r25, cpy_r_r27, 2, 0);
     CPy_DECREF(cpy_r_r25);
     if (unlikely(cpy_r_r28 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 150, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 156, CPyStatic_decorators___globals);
         goto CPyL59;
     }
     CPy_DECREF(cpy_r_r22);
     cpy_r_r29 = PyList_New(1);
     if (unlikely(cpy_r_r29 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 150, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 156, CPyStatic_decorators___globals);
         goto CPyL60;
     }
     CPy_INCREF(cpy_r_r20.f0);
@@ -2692,7 +2692,7 @@ CPyL22: ;
     cpy_r_r33 = CPyList_Extend(cpy_r_r29, cpy_r_r28);
     CPy_DECREF(cpy_r_r28);
     if (unlikely(cpy_r_r33 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 150, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 156, CPyStatic_decorators___globals);
         goto CPyL61;
     } else
         goto CPyL62;
@@ -2700,14 +2700,14 @@ CPyL26: ;
     cpy_r_r34 = PyList_AsTuple(cpy_r_r29);
     CPy_DECREF_NO_IMM(cpy_r_r29);
     if (unlikely(cpy_r_r34 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 150, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 156, CPyStatic_decorators___globals);
         goto CPyL56;
     }
     cpy_r_r35 = (CPyPtr)&((PyVarObject *)cpy_r_r34)->ob_size;
     cpy_r_r36 = *(int64_t *)cpy_r_r35;
     cpy_r_r37 = PyList_New(cpy_r_r36);
     if (unlikely(cpy_r_r37 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 150, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 156, CPyStatic_decorators___globals);
         goto CPyL63;
     }
     cpy_r_r38 = 0;
@@ -2719,7 +2719,7 @@ CPyL29: ;
     if (!cpy_r_r42) goto CPyL64;
     cpy_r_r43 = CPySequenceTuple_GetItem(cpy_r_r34, cpy_r_r38);
     if (unlikely(cpy_r_r43 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 150, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 156, CPyStatic_decorators___globals);
         goto CPyL65;
     }
     PyObject *__tmp6;
@@ -2758,7 +2758,7 @@ __LL7: ;
     }
     CPy_DECREF(cpy_r_r43);
     if (unlikely(cpy_r_r44.f0 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 150, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 156, CPyStatic_decorators___globals);
         goto CPyL65;
     }
     cpy_r_r45 = cpy_r_r44.f0;
@@ -2771,19 +2771,19 @@ __LL7: ;
     cpy_r_r48 = PyObject_Str(cpy_r_r46);
     CPy_DECREF(cpy_r_r46);
     if (unlikely(cpy_r_r48 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 150, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 156, CPyStatic_decorators___globals);
         goto CPyL66;
     }
     cpy_r_r49 = CPyStr_Build(3, cpy_r_r45, cpy_r_r47, cpy_r_r48);
     CPy_DECREF(cpy_r_r45);
     CPy_DECREF(cpy_r_r48);
     if (unlikely(cpy_r_r49 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 150, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 156, CPyStatic_decorators___globals);
         goto CPyL65;
     }
     cpy_r_r50 = CPyList_SetItemUnsafe(cpy_r_r37, cpy_r_r38, cpy_r_r49);
     if (unlikely(!cpy_r_r50)) {
-        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 150, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 156, CPyStatic_decorators___globals);
         goto CPyL65;
     }
     cpy_r_r51 = cpy_r_r38 + 2;
@@ -2793,13 +2793,13 @@ CPyL36: ;
     cpy_r_r52 = PyUnicode_Join(cpy_r_r19, cpy_r_r37);
     CPy_DECREF_NO_IMM(cpy_r_r37);
     if (unlikely(cpy_r_r52 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 150, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 156, CPyStatic_decorators___globals);
         goto CPyL56;
     }
     cpy_r_r53 = CPyStatics[25]; /* 'loaded %s %s for %s' */
     cpy_r_r54 = CPyObject_Size(cpy_r_r9);
     if (unlikely(cpy_r_r54 == CPY_INT_TAG)) {
-        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 151, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 157, CPyStatic_decorators___globals);
         goto CPyL67;
     }
     cpy_r_r55 = ((y____db___decorators___log_result_count_envObject *)cpy_r_r1)->_name;
@@ -2810,7 +2810,7 @@ CPyL36: ;
     }
     CPy_DECREF_NO_IMM(cpy_r_r1);
     if (unlikely(cpy_r_r55 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 151, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 157, CPyStatic_decorators___globals);
         goto CPyL68;
     }
 CPyL39: ;
@@ -2823,7 +2823,7 @@ CPyL40: ;
     PyErr_SetString(PyExc_NameError, "value for final name \"_result_count_logger_debug\" was not set");
     cpy_r_r57 = 0;
     if (unlikely(!cpy_r_r57)) {
-        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 151, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 157, CPyStatic_decorators___globals);
         goto CPyL45;
     }
     CPy_Unreachable();
@@ -2833,7 +2833,7 @@ CPyL42: ;
     cpy_r_r60 = (PyObject **)&cpy_r_r59;
     cpy_r_r61 = PyObject_Vectorcall(cpy_r_r56, cpy_r_r60, 4, 0);
     if (unlikely(cpy_r_r61 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 151, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 157, CPyStatic_decorators___globals);
         goto CPyL70;
     } else
         goto CPyL71;
@@ -2984,7 +2984,7 @@ PyObject *CPyPy_decorators___result_count_wrap_log_result_count_result_count_dec
 fail: ;
     CPy_DECREF(obj_args);
     CPy_DECREF(obj_kwargs);
-    CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 147, CPyStatic_decorators___globals);
+    CPy_AddTraceback("y/_db/decorators.py", "result_count_wrap", 153, CPyStatic_decorators___globals);
     return NULL;
 }
 
@@ -3048,14 +3048,14 @@ PyObject *CPyDef_decorators___result_count_deco_log_result_count_obj_____call__(
     PyObject *cpy_r_r20;
     cpy_r_r0 = ((y____db___decorators___result_count_deco_log_result_count_objObject *)cpy_r___mypyc_self__)->___mypyc_env__;
     if (unlikely(cpy_r_r0 == NULL)) {
-        CPy_AttributeError("y/_db/decorators.py", "result_count_deco", "result_count_deco_log_result_count_obj", "__mypyc_env__", 145, CPyStatic_decorators___globals);
+        CPy_AttributeError("y/_db/decorators.py", "result_count_deco", "result_count_deco_log_result_count_obj", "__mypyc_env__", 151, CPyStatic_decorators___globals);
         goto CPyL12;
     }
     CPy_INCREF_NO_IMM(cpy_r_r0);
 CPyL1: ;
     cpy_r_r1 = CPyDef_decorators___result_count_deco_log_result_count_env();
     if (unlikely(cpy_r_r1 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "result_count_deco", 145, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "result_count_deco", 151, CPyStatic_decorators___globals);
         goto CPyL13;
     }
     if (((y____db___decorators___result_count_deco_log_result_count_envObject *)cpy_r_r1)->___mypyc_env__ != NULL) {
@@ -3064,7 +3064,7 @@ CPyL1: ;
     ((y____db___decorators___result_count_deco_log_result_count_envObject *)cpy_r_r1)->___mypyc_env__ = cpy_r_r0;
     cpy_r_r2 = 1;
     if (unlikely(!cpy_r_r2)) {
-        CPy_AddTraceback("y/_db/decorators.py", "result_count_deco", 145, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "result_count_deco", 151, CPyStatic_decorators___globals);
         goto CPyL14;
     }
     CPy_INCREF(cpy_r_fn);
@@ -3074,12 +3074,12 @@ CPyL1: ;
     ((y____db___decorators___result_count_deco_log_result_count_envObject *)cpy_r_r1)->_fn = cpy_r_fn;
     cpy_r_r3 = 1;
     if (unlikely(!cpy_r_r3)) {
-        CPy_AddTraceback("y/_db/decorators.py", "result_count_deco", 145, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "result_count_deco", 151, CPyStatic_decorators___globals);
         goto CPyL14;
     }
     cpy_r_r4 = CPyDef_decorators___result_count_wrap_log_result_count_result_count_deco_obj();
     if (unlikely(cpy_r_r4 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "result_count_deco", 147, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "result_count_deco", 153, CPyStatic_decorators___globals);
         goto CPyL14;
     }
     CPy_INCREF_NO_IMM(cpy_r_r1);
@@ -3089,7 +3089,7 @@ CPyL1: ;
     ((y____db___decorators___result_count_wrap_log_result_count_result_count_deco_objObject *)cpy_r_r4)->___mypyc_env__ = cpy_r_r1;
     cpy_r_r5 = 1;
     if (unlikely(!cpy_r_r5)) {
-        CPy_AddTraceback("y/_db/decorators.py", "result_count_deco", 147, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "result_count_deco", 153, CPyStatic_decorators___globals);
         goto CPyL15;
     }
     cpy_r_r6 = ((y____db___decorators___result_count_deco_log_result_count_envObject *)cpy_r_r1)->_fn;
@@ -3100,7 +3100,7 @@ CPyL1: ;
     }
     CPy_DECREF_NO_IMM(cpy_r_r1);
     if (unlikely(cpy_r_r6 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "result_count_deco", 146, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "result_count_deco", 152, CPyStatic_decorators___globals);
         goto CPyL16;
     }
 CPyL7: ;
@@ -3108,7 +3108,7 @@ CPyL7: ;
     cpy_r_r8 = CPyStatics[14]; /* 'wraps' */
     cpy_r_r9 = CPyDict_GetItem(cpy_r_r7, cpy_r_r8);
     if (unlikely(cpy_r_r9 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "result_count_deco", 146, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "result_count_deco", 152, CPyStatic_decorators___globals);
         goto CPyL17;
     }
     PyObject *cpy_r_r10[1] = {cpy_r_r6};
@@ -3116,7 +3116,7 @@ CPyL7: ;
     cpy_r_r12 = PyObject_Vectorcall(cpy_r_r9, cpy_r_r11, 1, 0);
     CPy_DECREF(cpy_r_r9);
     if (unlikely(cpy_r_r12 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "result_count_deco", 146, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "result_count_deco", 152, CPyStatic_decorators___globals);
         goto CPyL17;
     }
     CPy_DECREF(cpy_r_r6);
@@ -3125,7 +3125,7 @@ CPyL7: ;
     cpy_r_r15 = PyObject_Vectorcall(cpy_r_r12, cpy_r_r14, 1, 0);
     CPy_DECREF(cpy_r_r12);
     if (unlikely(cpy_r_r15 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "result_count_deco", 147, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "result_count_deco", 153, CPyStatic_decorators___globals);
         goto CPyL16;
     }
     CPy_DECREF_NO_IMM(cpy_r_r4);
@@ -3136,7 +3136,7 @@ CPyL7: ;
     CPy_DECREF(cpy_r_r15);
     cpy_r_r19 = cpy_r_r18 >= 0;
     if (unlikely(!cpy_r_r19)) {
-        CPy_AddTraceback("y/_db/decorators.py", "result_count_deco", 147, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "result_count_deco", 153, CPyStatic_decorators___globals);
         goto CPyL18;
     }
     return cpy_r_r15;
@@ -3178,7 +3178,7 @@ PyObject *CPyPy_decorators___result_count_deco_log_result_count_obj_____call__(P
     PyObject *retval = CPyDef_decorators___result_count_deco_log_result_count_obj_____call__(arg___mypyc_self__, arg_fn);
     return retval;
 fail: ;
-    CPy_AddTraceback("y/_db/decorators.py", "result_count_deco", 145, CPyStatic_decorators___globals);
+    CPy_AddTraceback("y/_db/decorators.py", "result_count_deco", 151, CPyStatic_decorators___globals);
     return NULL;
 }
 
@@ -3198,7 +3198,7 @@ PyObject *CPyDef_decorators___log_result_count(PyObject *cpy_r_name, PyObject *c
 CPyL2: ;
     cpy_r_r1 = CPyDef_decorators___log_result_count_env();
     if (unlikely(cpy_r_r1 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "log_result_count", 121, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "log_result_count", 127, CPyStatic_decorators___globals);
         goto CPyL10;
     }
     CPy_INCREF(cpy_r_name);
@@ -3208,7 +3208,7 @@ CPyL2: ;
     ((y____db___decorators___log_result_count_envObject *)cpy_r_r1)->_name = cpy_r_name;
     cpy_r_r2 = 1;
     if (unlikely(!cpy_r_r2)) {
-        CPy_AddTraceback("y/_db/decorators.py", "log_result_count", 121, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "log_result_count", 127, CPyStatic_decorators___globals);
         goto CPyL11;
     }
     if (((y____db___decorators___log_result_count_envObject *)cpy_r_r1)->_arg_names != NULL) {
@@ -3217,12 +3217,12 @@ CPyL2: ;
     ((y____db___decorators___log_result_count_envObject *)cpy_r_r1)->_arg_names = cpy_r_arg_names;
     cpy_r_r3 = 1;
     if (unlikely(!cpy_r_r3)) {
-        CPy_AddTraceback("y/_db/decorators.py", "log_result_count", 121, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "log_result_count", 127, CPyStatic_decorators___globals);
         goto CPyL12;
     }
     cpy_r_r4 = CPyDef_decorators___result_count_deco_log_result_count_obj();
     if (unlikely(cpy_r_r4 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "log_result_count", 145, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "log_result_count", 151, CPyStatic_decorators___globals);
         goto CPyL12;
     }
     if (((y____db___decorators___result_count_deco_log_result_count_objObject *)cpy_r_r4)->___mypyc_env__ != NULL) {
@@ -3231,7 +3231,7 @@ CPyL2: ;
     ((y____db___decorators___result_count_deco_log_result_count_objObject *)cpy_r_r4)->___mypyc_env__ = cpy_r_r1;
     cpy_r_r5 = 1;
     if (unlikely(!cpy_r_r5)) {
-        CPy_AddTraceback("y/_db/decorators.py", "log_result_count", 145, CPyStatic_decorators___globals);
+        CPy_AddTraceback("y/_db/decorators.py", "log_result_count", 151, CPyStatic_decorators___globals);
         goto CPyL13;
     }
     cpy_r_result_count_deco = cpy_r_r4;
@@ -3281,7 +3281,7 @@ PyObject *CPyPy_decorators___log_result_count(PyObject *self, PyObject *const *a
     PyObject *retval = CPyDef_decorators___log_result_count(arg_name, arg_arg_names);
     return retval;
 fail: ;
-    CPy_AddTraceback("y/_db/decorators.py", "log_result_count", 121, CPyStatic_decorators___globals);
+    CPy_AddTraceback("y/_db/decorators.py", "log_result_count", 127, CPyStatic_decorators___globals);
     return NULL;
 }
 
@@ -3332,22 +3332,22 @@ char CPyDef_decorators_____top_level__(void) {
     PyObject *cpy_r_r45;
     PyObject *cpy_r_r46;
     PyObject *cpy_r_r47;
-    PyObject **cpy_r_r49;
+    PyObject *cpy_r_r48;
+    PyObject *cpy_r_r49;
     PyObject *cpy_r_r50;
     PyObject *cpy_r_r51;
     PyObject *cpy_r_r52;
-    int32_t cpy_r_r53;
-    char cpy_r_r54;
+    PyObject **cpy_r_r54;
     PyObject *cpy_r_r55;
     PyObject *cpy_r_r56;
     PyObject *cpy_r_r57;
-    PyObject *cpy_r_r58;
-    PyObject **cpy_r_r60;
+    int32_t cpy_r_r58;
+    char cpy_r_r59;
+    PyObject *cpy_r_r60;
     PyObject *cpy_r_r61;
     PyObject *cpy_r_r62;
     PyObject *cpy_r_r63;
-    int32_t cpy_r_r64;
-    char cpy_r_r65;
+    PyObject **cpy_r_r65;
     PyObject *cpy_r_r66;
     PyObject *cpy_r_r67;
     PyObject *cpy_r_r68;
@@ -3356,113 +3356,132 @@ char CPyDef_decorators_____top_level__(void) {
     PyObject *cpy_r_r71;
     PyObject *cpy_r_r72;
     PyObject *cpy_r_r73;
-    PyObject *cpy_r_r74;
-    PyObject *cpy_r_r75;
+    int32_t cpy_r_r74;
+    char cpy_r_r75;
     PyObject *cpy_r_r76;
     PyObject *cpy_r_r77;
-    PyObject **cpy_r_r79;
+    PyObject *cpy_r_r78;
+    PyObject *cpy_r_r79;
     PyObject *cpy_r_r80;
     PyObject *cpy_r_r81;
     PyObject *cpy_r_r82;
-    int32_t cpy_r_r83;
-    char cpy_r_r84;
+    PyObject **cpy_r_r84;
     PyObject *cpy_r_r85;
-    char cpy_r_r86;
+    PyObject *cpy_r_r86;
     PyObject *cpy_r_r87;
-    PyObject *cpy_r_r88;
-    PyObject *cpy_r_r89;
+    int32_t cpy_r_r88;
+    char cpy_r_r89;
     PyObject *cpy_r_r90;
-    int32_t cpy_r_r91;
-    char cpy_r_r92;
+    char cpy_r_r91;
+    PyObject *cpy_r_r92;
     PyObject *cpy_r_r93;
-    char cpy_r_r94;
+    PyObject *cpy_r_r94;
     PyObject *cpy_r_r95;
-    PyObject *cpy_r_r96;
-    PyObject *cpy_r_r97;
+    int32_t cpy_r_r96;
+    char cpy_r_r97;
     PyObject *cpy_r_r98;
-    int32_t cpy_r_r99;
-    char cpy_r_r100;
+    char cpy_r_r99;
+    PyObject *cpy_r_r100;
     PyObject *cpy_r_r101;
     PyObject *cpy_r_r102;
     PyObject *cpy_r_r103;
-    PyObject *cpy_r_r104;
-    PyObject **cpy_r_r106;
-    PyObject *cpy_r_r107;
+    int32_t cpy_r_r104;
+    char cpy_r_r105;
+    PyObject *cpy_r_r106;
+    char cpy_r_r107;
     PyObject *cpy_r_r108;
     PyObject *cpy_r_r109;
-    int32_t cpy_r_r110;
-    char cpy_r_r111;
+    char cpy_r_r110;
+    CPyTagged cpy_r_r111;
     PyObject *cpy_r_r112;
     PyObject *cpy_r_r113;
     PyObject *cpy_r_r114;
     PyObject *cpy_r_r115;
-    PyObject **cpy_r_r117;
-    PyObject *cpy_r_r118;
+    PyObject *cpy_r_r116;
+    PyObject **cpy_r_r118;
     PyObject *cpy_r_r119;
     PyObject *cpy_r_r120;
-    int32_t cpy_r_r121;
-    char cpy_r_r122;
-    PyObject *cpy_r_r123;
+    PyObject *cpy_r_r121;
+    int32_t cpy_r_r122;
+    char cpy_r_r123;
     PyObject *cpy_r_r124;
-    PyObject *cpy_r_r125;
-    int32_t cpy_r_r126;
-    char cpy_r_r127;
-    PyObject *cpy_r_r128;
-    PyObject *cpy_r_r129;
+    char cpy_r_r125;
+    PyObject *cpy_r_r126;
+    PyObject *cpy_r_r127;
+    char cpy_r_r128;
+    CPyTagged cpy_r_r129;
     PyObject *cpy_r_r130;
-    int32_t cpy_r_r131;
-    char cpy_r_r132;
+    PyObject *cpy_r_r131;
+    PyObject *cpy_r_r132;
     PyObject *cpy_r_r133;
     PyObject *cpy_r_r134;
-    PyObject *cpy_r_r135;
-    int32_t cpy_r_r136;
-    char cpy_r_r137;
+    PyObject **cpy_r_r136;
+    PyObject *cpy_r_r137;
     PyObject *cpy_r_r138;
     PyObject *cpy_r_r139;
-    PyObject *cpy_r_r140;
-    PyObject *cpy_r_r141;
+    int32_t cpy_r_r140;
+    char cpy_r_r141;
     PyObject *cpy_r_r142;
     PyObject *cpy_r_r143;
     PyObject *cpy_r_r144;
-    PyObject *cpy_r_r145;
-    PyObject *cpy_r_r146;
-    PyObject **cpy_r_r148;
+    int32_t cpy_r_r145;
+    char cpy_r_r146;
+    PyObject *cpy_r_r147;
+    PyObject *cpy_r_r148;
     PyObject *cpy_r_r149;
-    PyObject *cpy_r_r150;
-    PyObject *cpy_r_r151;
-    int32_t cpy_r_r152;
-    char cpy_r_r153;
+    int32_t cpy_r_r150;
+    char cpy_r_r151;
+    PyObject *cpy_r_r152;
+    PyObject *cpy_r_r153;
     PyObject *cpy_r_r154;
-    char cpy_r_r155;
-    PyObject *cpy_r_r156;
+    int32_t cpy_r_r155;
+    char cpy_r_r156;
     PyObject *cpy_r_r157;
     PyObject *cpy_r_r158;
     PyObject *cpy_r_r159;
-    int32_t cpy_r_r160;
-    char cpy_r_r161;
+    PyObject *cpy_r_r160;
+    PyObject *cpy_r_r161;
     PyObject *cpy_r_r162;
-    char cpy_r_r163;
+    PyObject *cpy_r_r163;
     PyObject *cpy_r_r164;
     PyObject *cpy_r_r165;
-    PyObject *cpy_r_r166;
-    PyObject *cpy_r_r167;
-    int32_t cpy_r_r168;
-    char cpy_r_r169;
+    PyObject **cpy_r_r167;
+    PyObject *cpy_r_r168;
+    PyObject *cpy_r_r169;
     PyObject *cpy_r_r170;
-    PyObject *cpy_r_r171;
-    PyObject *cpy_r_r172;
+    int32_t cpy_r_r171;
+    char cpy_r_r172;
     PyObject *cpy_r_r173;
-    PyObject *cpy_r_r174;
+    char cpy_r_r174;
     PyObject *cpy_r_r175;
-    CPyTagged cpy_r_r176;
-    tuple_T2OI cpy_r_r177;
+    PyObject *cpy_r_r176;
+    PyObject *cpy_r_r177;
     PyObject *cpy_r_r178;
-    PyObject *cpy_r_r179;
-    PyObject *cpy_r_r180;
-    int32_t cpy_r_r181;
+    int32_t cpy_r_r179;
+    char cpy_r_r180;
+    PyObject *cpy_r_r181;
     char cpy_r_r182;
     PyObject *cpy_r_r183;
-    char cpy_r_r184;
+    PyObject *cpy_r_r184;
+    PyObject *cpy_r_r185;
+    PyObject *cpy_r_r186;
+    int32_t cpy_r_r187;
+    char cpy_r_r188;
+    PyObject *cpy_r_r189;
+    PyObject *cpy_r_r190;
+    PyObject *cpy_r_r191;
+    PyObject *cpy_r_r192;
+    PyObject *cpy_r_r193;
+    PyObject *cpy_r_r194;
+    CPyTagged cpy_r_r195;
+    tuple_T2OI cpy_r_r196;
+    PyObject *cpy_r_r197;
+    PyObject *cpy_r_r198;
+    PyObject *cpy_r_r199;
+    int32_t cpy_r_r200;
+    char cpy_r_r201;
+    PyObject *cpy_r_r202;
+    char cpy_r_r203;
     cpy_r_r0 = CPyModule_builtins;
     cpy_r_r1 = (PyObject *)&_Py_NoneStruct;
     cpy_r_r2 = cpy_r_r0 != cpy_r_r1;
@@ -3471,7 +3490,7 @@ char CPyDef_decorators_____top_level__(void) {
     cpy_r_r4 = PyImport_Import(cpy_r_r3);
     if (unlikely(cpy_r_r4 == NULL)) {
         CPy_AddTraceback("y/_db/decorators.py", "<module>", -1, CPyStatic_decorators___globals);
-        goto CPyL67;
+        goto CPyL84;
     }
     CPyModule_builtins = cpy_r_r4;
     CPy_INCREF(CPyModule_builtins);
@@ -3483,80 +3502,80 @@ CPyL3: ;
     cpy_r_r8 = (void *)&cpy_r_r7;
     int64_t cpy_r_r9[2] = {1, 2};
     cpy_r_r10 = (void *)&cpy_r_r9;
-    cpy_r_r11 = CPyStatics[492]; /* (('logging', 'logging', 'logging'),
+    cpy_r_r11 = CPyStatics[493]; /* (('logging', 'logging', 'logging'),
                                     ('time', 'time', 'time')) */
     cpy_r_r12 = CPyStatic_decorators___globals;
     cpy_r_r13 = CPyStatics[30]; /* 'y/_db/decorators.py' */
     cpy_r_r14 = CPyStatics[31]; /* '<module>' */
     cpy_r_r15 = CPyImport_ImportMany(cpy_r_r11, cpy_r_r8, cpy_r_r12, cpy_r_r13, cpy_r_r14, cpy_r_r10);
-    if (!cpy_r_r15) goto CPyL67;
-    cpy_r_r16 = CPyStatics[493]; /* ('lru_cache', 'wraps') */
+    if (!cpy_r_r15) goto CPyL84;
+    cpy_r_r16 = CPyStatics[494]; /* ('lru_cache', 'wraps') */
     cpy_r_r17 = CPyStatics[32]; /* 'functools' */
     cpy_r_r18 = CPyStatic_decorators___globals;
     cpy_r_r19 = CPyImport_ImportFromMany(cpy_r_r17, cpy_r_r16, cpy_r_r16, cpy_r_r18);
     if (unlikely(cpy_r_r19 == NULL)) {
         CPy_AddTraceback("y/_db/decorators.py", "<module>", 3, CPyStatic_decorators___globals);
-        goto CPyL67;
+        goto CPyL84;
     }
     CPyModule_functools = cpy_r_r19;
     CPy_INCREF(CPyModule_functools);
     CPy_DECREF(cpy_r_r19);
-    cpy_r_r20 = CPyStatics[494]; /* ('Callable', 'Final', 'Iterable', 'TypeVar') */
+    cpy_r_r20 = CPyStatics[495]; /* ('Callable', 'Final', 'Iterable', 'TypeVar') */
     cpy_r_r21 = CPyStatics[37]; /* 'typing' */
     cpy_r_r22 = CPyStatic_decorators___globals;
     cpy_r_r23 = CPyImport_ImportFromMany(cpy_r_r21, cpy_r_r20, cpy_r_r20, cpy_r_r22);
     if (unlikely(cpy_r_r23 == NULL)) {
         CPy_AddTraceback("y/_db/decorators.py", "<module>", 4, CPyStatic_decorators___globals);
-        goto CPyL67;
+        goto CPyL84;
     }
     CPyModule_typing = cpy_r_r23;
     CPy_INCREF(CPyModule_typing);
     CPy_DECREF(cpy_r_r23);
-    cpy_r_r24 = CPyStatics[495]; /* ('ParamSpec',) */
+    cpy_r_r24 = CPyStatics[496]; /* ('ParamSpec',) */
     cpy_r_r25 = CPyStatics[39]; /* 'typing_extensions' */
     cpy_r_r26 = CPyStatic_decorators___globals;
     cpy_r_r27 = CPyImport_ImportFromMany(cpy_r_r25, cpy_r_r24, cpy_r_r24, cpy_r_r26);
     if (unlikely(cpy_r_r27 == NULL)) {
         CPy_AddTraceback("y/_db/decorators.py", "<module>", 5, CPyStatic_decorators___globals);
-        goto CPyL67;
+        goto CPyL84;
     }
     CPyModule_typing_extensions = cpy_r_r27;
     CPy_INCREF(CPyModule_typing_extensions);
     CPy_DECREF(cpy_r_r27);
-    cpy_r_r28 = CPyStatics[496]; /* ('PruningThreadPoolExecutor', 'a_sync') */
+    cpy_r_r28 = CPyStatics[497]; /* ('PruningThreadPoolExecutor', 'a_sync') */
     cpy_r_r29 = CPyStatics[18]; /* 'a_sync' */
     cpy_r_r30 = CPyStatic_decorators___globals;
     cpy_r_r31 = CPyImport_ImportFromMany(cpy_r_r29, cpy_r_r28, cpy_r_r28, cpy_r_r30);
     if (unlikely(cpy_r_r31 == NULL)) {
         CPy_AddTraceback("y/_db/decorators.py", "<module>", 7, CPyStatic_decorators___globals);
-        goto CPyL67;
+        goto CPyL84;
     }
     CPyModule_a_sync = cpy_r_r31;
     CPy_INCREF(CPyModule_a_sync);
     CPy_DECREF(cpy_r_r31);
-    cpy_r_r32 = CPyStatics[497]; /* ('ASyncFunction',) */
+    cpy_r_r32 = CPyStatics[498]; /* ('ASyncFunction',) */
     cpy_r_r33 = CPyStatics[42]; /* 'a_sync.a_sync' */
     cpy_r_r34 = CPyStatic_decorators___globals;
     cpy_r_r35 = CPyImport_ImportFromMany(cpy_r_r33, cpy_r_r32, cpy_r_r32, cpy_r_r34);
     if (unlikely(cpy_r_r35 == NULL)) {
         CPy_AddTraceback("y/_db/decorators.py", "<module>", 8, CPyStatic_decorators___globals);
-        goto CPyL67;
+        goto CPyL84;
     }
     CPyModule_a_sync___a_sync = cpy_r_r35;
     CPy_INCREF(CPyModule_a_sync___a_sync);
     CPy_DECREF(cpy_r_r35);
-    cpy_r_r36 = CPyStatics[498]; /* ('chain',) */
+    cpy_r_r36 = CPyStatics[499]; /* ('chain',) */
     cpy_r_r37 = CPyStatics[44]; /* 'brownie' */
     cpy_r_r38 = CPyStatic_decorators___globals;
     cpy_r_r39 = CPyImport_ImportFromMany(cpy_r_r37, cpy_r_r36, cpy_r_r36, cpy_r_r38);
     if (unlikely(cpy_r_r39 == NULL)) {
         CPy_AddTraceback("y/_db/decorators.py", "<module>", 9, CPyStatic_decorators___globals);
-        goto CPyL67;
+        goto CPyL84;
     }
     CPyModule_brownie = cpy_r_r39;
     CPy_INCREF(CPyModule_brownie);
     CPy_DECREF(cpy_r_r39);
-    cpy_r_r40 = CPyStatics[499]; /* ('CommitException', 'OperationalError',
+    cpy_r_r40 = CPyStatics[500]; /* ('CommitException', 'OperationalError',
                                     'TransactionError', 'UnexpectedError', 'commit',
                                     'db_session') */
     cpy_r_r41 = CPyStatics[45]; /* 'pony.orm' */
@@ -3564,433 +3583,523 @@ CPyL3: ;
     cpy_r_r43 = CPyImport_ImportFromMany(cpy_r_r41, cpy_r_r40, cpy_r_r40, cpy_r_r42);
     if (unlikely(cpy_r_r43 == NULL)) {
         CPy_AddTraceback("y/_db/decorators.py", "<module>", 10, CPyStatic_decorators___globals);
-        goto CPyL67;
+        goto CPyL84;
     }
     CPyModule_pony___orm = cpy_r_r43;
     CPy_INCREF(CPyModule_pony___orm);
     CPy_DECREF(cpy_r_r43);
-    cpy_r_r44 = CPyStatics[46]; /* '_T' */
-    cpy_r_r45 = CPyStatic_decorators___globals;
-    cpy_r_r46 = CPyStatics[36]; /* 'TypeVar' */
-    cpy_r_r47 = CPyDict_GetItem(cpy_r_r45, cpy_r_r46);
-    if (unlikely(cpy_r_r47 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<module>", 20, CPyStatic_decorators___globals);
-        goto CPyL67;
+    cpy_r_r44 = CPyStatics[501]; /* ('ENVIRONMENT_VARIABLES',) */
+    cpy_r_r45 = CPyStatics[502]; /* ('ENVS',) */
+    cpy_r_r46 = CPyStatics[48]; /* 'y' */
+    cpy_r_r47 = CPyStatic_decorators___globals;
+    cpy_r_r48 = CPyImport_ImportFromMany(cpy_r_r46, cpy_r_r44, cpy_r_r45, cpy_r_r47);
+    if (unlikely(cpy_r_r48 == NULL)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 19, CPyStatic_decorators___globals);
+        goto CPyL84;
     }
-    PyObject *cpy_r_r48[1] = {cpy_r_r44};
-    cpy_r_r49 = (PyObject **)&cpy_r_r48;
-    cpy_r_r50 = PyObject_Vectorcall(cpy_r_r47, cpy_r_r49, 1, 0);
-    CPy_DECREF(cpy_r_r47);
-    if (unlikely(cpy_r_r50 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<module>", 20, CPyStatic_decorators___globals);
-        goto CPyL67;
+    CPyModule_y = cpy_r_r48;
+    CPy_INCREF(CPyModule_y);
+    CPy_DECREF(cpy_r_r48);
+    cpy_r_r49 = CPyStatics[49]; /* '_T' */
+    cpy_r_r50 = CPyStatic_decorators___globals;
+    cpy_r_r51 = CPyStatics[36]; /* 'TypeVar' */
+    cpy_r_r52 = CPyDict_GetItem(cpy_r_r50, cpy_r_r51);
+    if (unlikely(cpy_r_r52 == NULL)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 22, CPyStatic_decorators___globals);
+        goto CPyL84;
     }
-    cpy_r_r51 = CPyStatic_decorators___globals;
-    cpy_r_r52 = CPyStatics[46]; /* '_T' */
-    cpy_r_r53 = CPyDict_SetItem(cpy_r_r51, cpy_r_r52, cpy_r_r50);
-    CPy_DECREF(cpy_r_r50);
-    cpy_r_r54 = cpy_r_r53 >= 0;
-    if (unlikely(!cpy_r_r54)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<module>", 20, CPyStatic_decorators___globals);
-        goto CPyL67;
+    PyObject *cpy_r_r53[1] = {cpy_r_r49};
+    cpy_r_r54 = (PyObject **)&cpy_r_r53;
+    cpy_r_r55 = PyObject_Vectorcall(cpy_r_r52, cpy_r_r54, 1, 0);
+    CPy_DECREF(cpy_r_r52);
+    if (unlikely(cpy_r_r55 == NULL)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 22, CPyStatic_decorators___globals);
+        goto CPyL84;
     }
-    cpy_r_r55 = CPyStatics[47]; /* '_P' */
     cpy_r_r56 = CPyStatic_decorators___globals;
-    cpy_r_r57 = CPyStatics[38]; /* 'ParamSpec' */
-    cpy_r_r58 = CPyDict_GetItem(cpy_r_r56, cpy_r_r57);
-    if (unlikely(cpy_r_r58 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<module>", 21, CPyStatic_decorators___globals);
-        goto CPyL67;
+    cpy_r_r57 = CPyStatics[49]; /* '_T' */
+    cpy_r_r58 = CPyDict_SetItem(cpy_r_r56, cpy_r_r57, cpy_r_r55);
+    CPy_DECREF(cpy_r_r55);
+    cpy_r_r59 = cpy_r_r58 >= 0;
+    if (unlikely(!cpy_r_r59)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 22, CPyStatic_decorators___globals);
+        goto CPyL84;
     }
-    PyObject *cpy_r_r59[1] = {cpy_r_r55};
-    cpy_r_r60 = (PyObject **)&cpy_r_r59;
-    cpy_r_r61 = PyObject_Vectorcall(cpy_r_r58, cpy_r_r60, 1, 0);
-    CPy_DECREF(cpy_r_r58);
-    if (unlikely(cpy_r_r61 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<module>", 21, CPyStatic_decorators___globals);
-        goto CPyL67;
+    cpy_r_r60 = CPyStatics[50]; /* '_P' */
+    cpy_r_r61 = CPyStatic_decorators___globals;
+    cpy_r_r62 = CPyStatics[38]; /* 'ParamSpec' */
+    cpy_r_r63 = CPyDict_GetItem(cpy_r_r61, cpy_r_r62);
+    if (unlikely(cpy_r_r63 == NULL)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 23, CPyStatic_decorators___globals);
+        goto CPyL84;
     }
-    cpy_r_r62 = CPyStatic_decorators___globals;
-    cpy_r_r63 = CPyStatics[47]; /* '_P' */
-    cpy_r_r64 = CPyDict_SetItem(cpy_r_r62, cpy_r_r63, cpy_r_r61);
-    CPy_DECREF(cpy_r_r61);
-    cpy_r_r65 = cpy_r_r64 >= 0;
-    if (unlikely(!cpy_r_r65)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<module>", 21, CPyStatic_decorators___globals);
-        goto CPyL67;
+    PyObject *cpy_r_r64[1] = {cpy_r_r60};
+    cpy_r_r65 = (PyObject **)&cpy_r_r64;
+    cpy_r_r66 = PyObject_Vectorcall(cpy_r_r63, cpy_r_r65, 1, 0);
+    CPy_DECREF(cpy_r_r63);
+    if (unlikely(cpy_r_r66 == NULL)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 23, CPyStatic_decorators___globals);
+        goto CPyL84;
     }
-    CPyStatic_decorators___DEBUG = 20;
-    cpy_r_r66 = CPyStatic_decorators___globals;
-    cpy_r_r67 = CPyStatics[48]; /* 'DEBUG' */
-    cpy_r_r68 = CPyStatics[466]; /* 10 */
-    cpy_r_r69 = CPyDict_SetItem(cpy_r_r66, cpy_r_r67, cpy_r_r68);
+    cpy_r_r67 = CPyStatic_decorators___globals;
+    cpy_r_r68 = CPyStatics[50]; /* '_P' */
+    cpy_r_r69 = CPyDict_SetItem(cpy_r_r67, cpy_r_r68, cpy_r_r66);
+    CPy_DECREF(cpy_r_r66);
     cpy_r_r70 = cpy_r_r69 >= 0;
     if (unlikely(!cpy_r_r70)) {
         CPy_AddTraceback("y/_db/decorators.py", "<module>", 23, CPyStatic_decorators___globals);
-        goto CPyL67;
+        goto CPyL84;
     }
+    CPyStatic_decorators___DEBUG = 20;
     cpy_r_r71 = CPyStatic_decorators___globals;
-    cpy_r_r72 = CPyStatics[9]; /* '__name__' */
-    cpy_r_r73 = CPyDict_GetItem(cpy_r_r71, cpy_r_r72);
-    if (unlikely(cpy_r_r73 == NULL)) {
+    cpy_r_r72 = CPyStatics[51]; /* 'DEBUG' */
+    cpy_r_r73 = CPyStatics[468]; /* 10 */
+    cpy_r_r74 = CPyDict_SetItem(cpy_r_r71, cpy_r_r72, cpy_r_r73);
+    cpy_r_r75 = cpy_r_r74 >= 0;
+    if (unlikely(!cpy_r_r75)) {
         CPy_AddTraceback("y/_db/decorators.py", "<module>", 25, CPyStatic_decorators___globals);
-        goto CPyL67;
+        goto CPyL84;
     }
-    if (likely(PyUnicode_Check(cpy_r_r73)))
-        cpy_r_r74 = cpy_r_r73;
+    cpy_r_r76 = CPyStatic_decorators___globals;
+    cpy_r_r77 = CPyStatics[9]; /* '__name__' */
+    cpy_r_r78 = CPyDict_GetItem(cpy_r_r76, cpy_r_r77);
+    if (unlikely(cpy_r_r78 == NULL)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 27, CPyStatic_decorators___globals);
+        goto CPyL84;
+    }
+    if (likely(PyUnicode_Check(cpy_r_r78)))
+        cpy_r_r79 = cpy_r_r78;
     else {
-        CPy_TypeErrorTraceback("y/_db/decorators.py", "<module>", 25, CPyStatic_decorators___globals, "str", cpy_r_r73);
-        goto CPyL67;
+        CPy_TypeErrorTraceback("y/_db/decorators.py", "<module>", 27, CPyStatic_decorators___globals, "str", cpy_r_r78);
+        goto CPyL84;
     }
-    cpy_r_r75 = CPyModule_logging;
-    cpy_r_r76 = CPyStatics[49]; /* 'getLogger' */
-    cpy_r_r77 = CPyObject_GetAttr(cpy_r_r75, cpy_r_r76);
-    if (unlikely(cpy_r_r77 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<module>", 25, CPyStatic_decorators___globals);
-        goto CPyL68;
+    cpy_r_r80 = CPyModule_logging;
+    cpy_r_r81 = CPyStatics[52]; /* 'getLogger' */
+    cpy_r_r82 = CPyObject_GetAttr(cpy_r_r80, cpy_r_r81);
+    if (unlikely(cpy_r_r82 == NULL)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 27, CPyStatic_decorators___globals);
+        goto CPyL85;
     }
-    PyObject *cpy_r_r78[1] = {cpy_r_r74};
-    cpy_r_r79 = (PyObject **)&cpy_r_r78;
-    cpy_r_r80 = PyObject_Vectorcall(cpy_r_r77, cpy_r_r79, 1, 0);
-    CPy_DECREF(cpy_r_r77);
-    if (unlikely(cpy_r_r80 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<module>", 25, CPyStatic_decorators___globals);
-        goto CPyL68;
+    PyObject *cpy_r_r83[1] = {cpy_r_r79};
+    cpy_r_r84 = (PyObject **)&cpy_r_r83;
+    cpy_r_r85 = PyObject_Vectorcall(cpy_r_r82, cpy_r_r84, 1, 0);
+    CPy_DECREF(cpy_r_r82);
+    if (unlikely(cpy_r_r85 == NULL)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 27, CPyStatic_decorators___globals);
+        goto CPyL85;
     }
-    CPy_DECREF(cpy_r_r74);
-    CPyStatic_decorators___logger = cpy_r_r80;
+    CPy_DECREF(cpy_r_r79);
+    CPyStatic_decorators___logger = cpy_r_r85;
     CPy_INCREF(CPyStatic_decorators___logger);
-    cpy_r_r81 = CPyStatic_decorators___globals;
-    cpy_r_r82 = CPyStatics[50]; /* 'logger' */
-    cpy_r_r83 = CPyDict_SetItem(cpy_r_r81, cpy_r_r82, cpy_r_r80);
-    CPy_DECREF(cpy_r_r80);
-    cpy_r_r84 = cpy_r_r83 >= 0;
-    if (unlikely(!cpy_r_r84)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<module>", 25, CPyStatic_decorators___globals);
-        goto CPyL67;
+    cpy_r_r86 = CPyStatic_decorators___globals;
+    cpy_r_r87 = CPyStatics[53]; /* 'logger' */
+    cpy_r_r88 = CPyDict_SetItem(cpy_r_r86, cpy_r_r87, cpy_r_r85);
+    CPy_DECREF(cpy_r_r85);
+    cpy_r_r89 = cpy_r_r88 >= 0;
+    if (unlikely(!cpy_r_r89)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 27, CPyStatic_decorators___globals);
+        goto CPyL84;
     }
-    cpy_r_r85 = CPyStatic_decorators___logger;
-    if (likely(cpy_r_r85 != NULL)) goto CPyL26;
+    cpy_r_r90 = CPyStatic_decorators___logger;
+    if (likely(cpy_r_r90 != NULL)) goto CPyL27;
     PyErr_SetString(PyExc_NameError, "value for final name \"logger\" was not set");
-    cpy_r_r86 = 0;
-    if (unlikely(!cpy_r_r86)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<module>", 26, CPyStatic_decorators___globals);
-        goto CPyL67;
+    cpy_r_r91 = 0;
+    if (unlikely(!cpy_r_r91)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 28, CPyStatic_decorators___globals);
+        goto CPyL84;
     }
     CPy_Unreachable();
-CPyL26: ;
-    cpy_r_r87 = CPyStatics[51]; /* 'warning' */
-    cpy_r_r88 = CPyObject_GetAttr(cpy_r_r85, cpy_r_r87);
-    if (unlikely(cpy_r_r88 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<module>", 26, CPyStatic_decorators___globals);
-        goto CPyL67;
+CPyL27: ;
+    cpy_r_r92 = CPyStatics[54]; /* 'warning' */
+    cpy_r_r93 = CPyObject_GetAttr(cpy_r_r90, cpy_r_r92);
+    if (unlikely(cpy_r_r93 == NULL)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 28, CPyStatic_decorators___globals);
+        goto CPyL84;
     }
-    CPyStatic_decorators___log_warning = cpy_r_r88;
+    CPyStatic_decorators___log_warning = cpy_r_r93;
     CPy_INCREF(CPyStatic_decorators___log_warning);
-    cpy_r_r89 = CPyStatic_decorators___globals;
-    cpy_r_r90 = CPyStatics[52]; /* 'log_warning' */
-    cpy_r_r91 = CPyDict_SetItem(cpy_r_r89, cpy_r_r90, cpy_r_r88);
-    CPy_DECREF(cpy_r_r88);
-    cpy_r_r92 = cpy_r_r91 >= 0;
-    if (unlikely(!cpy_r_r92)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<module>", 26, CPyStatic_decorators___globals);
-        goto CPyL67;
+    cpy_r_r94 = CPyStatic_decorators___globals;
+    cpy_r_r95 = CPyStatics[55]; /* 'log_warning' */
+    cpy_r_r96 = CPyDict_SetItem(cpy_r_r94, cpy_r_r95, cpy_r_r93);
+    CPy_DECREF(cpy_r_r93);
+    cpy_r_r97 = cpy_r_r96 >= 0;
+    if (unlikely(!cpy_r_r97)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 28, CPyStatic_decorators___globals);
+        goto CPyL84;
     }
-    cpy_r_r93 = CPyStatic_decorators___logger;
-    if (likely(cpy_r_r93 != NULL)) goto CPyL31;
+    cpy_r_r98 = CPyStatic_decorators___logger;
+    if (likely(cpy_r_r98 != NULL)) goto CPyL32;
     PyErr_SetString(PyExc_NameError, "value for final name \"logger\" was not set");
-    cpy_r_r94 = 0;
-    if (unlikely(!cpy_r_r94)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<module>", 27, CPyStatic_decorators___globals);
-        goto CPyL67;
+    cpy_r_r99 = 0;
+    if (unlikely(!cpy_r_r99)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 29, CPyStatic_decorators___globals);
+        goto CPyL84;
     }
     CPy_Unreachable();
-CPyL31: ;
-    cpy_r_r95 = CPyStatics[53]; /* 'debug' */
-    cpy_r_r96 = CPyObject_GetAttr(cpy_r_r93, cpy_r_r95);
-    if (unlikely(cpy_r_r96 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<module>", 27, CPyStatic_decorators___globals);
-        goto CPyL67;
+CPyL32: ;
+    cpy_r_r100 = CPyStatics[56]; /* 'debug' */
+    cpy_r_r101 = CPyObject_GetAttr(cpy_r_r98, cpy_r_r100);
+    if (unlikely(cpy_r_r101 == NULL)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 29, CPyStatic_decorators___globals);
+        goto CPyL84;
     }
-    CPyStatic_decorators___log_debug = cpy_r_r96;
+    CPyStatic_decorators___log_debug = cpy_r_r101;
     CPy_INCREF(CPyStatic_decorators___log_debug);
-    cpy_r_r97 = CPyStatic_decorators___globals;
-    cpy_r_r98 = CPyStatics[54]; /* 'log_debug' */
-    cpy_r_r99 = CPyDict_SetItem(cpy_r_r97, cpy_r_r98, cpy_r_r96);
-    CPy_DECREF(cpy_r_r96);
-    cpy_r_r100 = cpy_r_r99 >= 0;
-    if (unlikely(!cpy_r_r100)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<module>", 27, CPyStatic_decorators___globals);
-        goto CPyL67;
-    }
-    cpy_r_r101 = CPyStatic_decorators___globals;
-    cpy_r_r102 = CPyStatics[40]; /* 'PruningThreadPoolExecutor' */
-    cpy_r_r103 = CPyDict_GetItem(cpy_r_r101, cpy_r_r102);
-    if (unlikely(cpy_r_r103 == NULL)) {
+    cpy_r_r102 = CPyStatic_decorators___globals;
+    cpy_r_r103 = CPyStatics[57]; /* 'log_debug' */
+    cpy_r_r104 = CPyDict_SetItem(cpy_r_r102, cpy_r_r103, cpy_r_r101);
+    CPy_DECREF(cpy_r_r101);
+    cpy_r_r105 = cpy_r_r104 >= 0;
+    if (unlikely(!cpy_r_r105)) {
         CPy_AddTraceback("y/_db/decorators.py", "<module>", 29, CPyStatic_decorators___globals);
-        goto CPyL67;
+        goto CPyL84;
     }
-    cpy_r_r104 = CPyStatics[467]; /* 12 */
-    PyObject *cpy_r_r105[1] = {cpy_r_r104};
-    cpy_r_r106 = (PyObject **)&cpy_r_r105;
-    cpy_r_r107 = PyObject_Vectorcall(cpy_r_r103, cpy_r_r106, 1, 0);
-    CPy_DECREF(cpy_r_r103);
-    if (unlikely(cpy_r_r107 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<module>", 29, CPyStatic_decorators___globals);
-        goto CPyL67;
+    cpy_r_r106 = CPyStatic_ENVIRONMENT_VARIABLES___DB_PROVIDER;
+    if (likely(cpy_r_r106 != NULL)) goto CPyL37;
+    PyErr_SetString(PyExc_NameError, "value for final name \"DB_PROVIDER\" was not set");
+    cpy_r_r107 = 0;
+    if (unlikely(!cpy_r_r107)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 32, CPyStatic_decorators___globals);
+        goto CPyL84;
     }
-    CPyStatic_decorators___ydb_read_threads = cpy_r_r107;
+    CPy_Unreachable();
+CPyL37: ;
+    cpy_r_r108 = CPyStatics[58]; /* 'postgres' */
+    cpy_r_r109 = PyObject_RichCompare(cpy_r_r106, cpy_r_r108, 2);
+    if (unlikely(cpy_r_r109 == NULL)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 32, CPyStatic_decorators___globals);
+        goto CPyL84;
+    }
+    if (unlikely(!PyBool_Check(cpy_r_r109))) {
+        CPy_TypeError("bool", cpy_r_r109); cpy_r_r110 = 2;
+    } else
+        cpy_r_r110 = cpy_r_r109 == Py_True;
+    CPy_DECREF(cpy_r_r109);
+    if (unlikely(cpy_r_r110 == 2)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 32, CPyStatic_decorators___globals);
+        goto CPyL84;
+    }
+    if (!cpy_r_r110) goto CPyL41;
+    cpy_r_r111 = 24;
+    goto CPyL42;
+CPyL41: ;
+    cpy_r_r111 = 8;
+CPyL42: ;
+    cpy_r_r112 = CPyStatics[59]; /* 'ydb read threads' */
+    cpy_r_r113 = CPyStatic_decorators___globals;
+    cpy_r_r114 = CPyStatics[40]; /* 'PruningThreadPoolExecutor' */
+    cpy_r_r115 = CPyDict_GetItem(cpy_r_r113, cpy_r_r114);
+    if (unlikely(cpy_r_r115 == NULL)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 31, CPyStatic_decorators___globals);
+        goto CPyL86;
+    }
+    cpy_r_r116 = CPyTagged_StealAsObject(cpy_r_r111);
+    PyObject *cpy_r_r117[2] = {cpy_r_r116, cpy_r_r112};
+    cpy_r_r118 = (PyObject **)&cpy_r_r117;
+    cpy_r_r119 = PyObject_Vectorcall(cpy_r_r115, cpy_r_r118, 2, 0);
+    CPy_DECREF(cpy_r_r115);
+    if (unlikely(cpy_r_r119 == NULL)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 31, CPyStatic_decorators___globals);
+        goto CPyL87;
+    }
+    CPy_DECREF(cpy_r_r116);
+    CPyStatic_decorators___ydb_read_threads = cpy_r_r119;
     CPy_INCREF(CPyStatic_decorators___ydb_read_threads);
-    cpy_r_r108 = CPyStatic_decorators___globals;
-    cpy_r_r109 = CPyStatics[55]; /* 'ydb_read_threads' */
-    cpy_r_r110 = CPyDict_SetItem(cpy_r_r108, cpy_r_r109, cpy_r_r107);
-    CPy_DECREF(cpy_r_r107);
-    cpy_r_r111 = cpy_r_r110 >= 0;
-    if (unlikely(!cpy_r_r111)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<module>", 29, CPyStatic_decorators___globals);
-        goto CPyL67;
+    cpy_r_r120 = CPyStatic_decorators___globals;
+    cpy_r_r121 = CPyStatics[60]; /* 'ydb_read_threads' */
+    cpy_r_r122 = CPyDict_SetItem(cpy_r_r120, cpy_r_r121, cpy_r_r119);
+    CPy_DECREF(cpy_r_r119);
+    cpy_r_r123 = cpy_r_r122 >= 0;
+    if (unlikely(!cpy_r_r123)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 31, CPyStatic_decorators___globals);
+        goto CPyL84;
     }
-    cpy_r_r112 = CPyStatic_decorators___globals;
-    cpy_r_r113 = CPyStatics[40]; /* 'PruningThreadPoolExecutor' */
-    cpy_r_r114 = CPyDict_GetItem(cpy_r_r112, cpy_r_r113);
-    if (unlikely(cpy_r_r114 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<module>", 30, CPyStatic_decorators___globals);
-        goto CPyL67;
+    cpy_r_r124 = CPyStatic_ENVIRONMENT_VARIABLES___DB_PROVIDER;
+    if (likely(cpy_r_r124 != NULL)) goto CPyL48;
+    PyErr_SetString(PyExc_NameError, "value for final name \"DB_PROVIDER\" was not set");
+    cpy_r_r125 = 0;
+    if (unlikely(!cpy_r_r125)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 35, CPyStatic_decorators___globals);
+        goto CPyL84;
     }
-    cpy_r_r115 = CPyStatics[467]; /* 12 */
-    PyObject *cpy_r_r116[1] = {cpy_r_r115};
-    cpy_r_r117 = (PyObject **)&cpy_r_r116;
-    cpy_r_r118 = PyObject_Vectorcall(cpy_r_r114, cpy_r_r117, 1, 0);
-    CPy_DECREF(cpy_r_r114);
-    if (unlikely(cpy_r_r118 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<module>", 30, CPyStatic_decorators___globals);
-        goto CPyL67;
+    CPy_Unreachable();
+CPyL48: ;
+    cpy_r_r126 = CPyStatics[58]; /* 'postgres' */
+    cpy_r_r127 = PyObject_RichCompare(cpy_r_r124, cpy_r_r126, 2);
+    if (unlikely(cpy_r_r127 == NULL)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 35, CPyStatic_decorators___globals);
+        goto CPyL84;
     }
-    CPyStatic_decorators___ydb_write_threads = cpy_r_r118;
-    CPy_INCREF(CPyStatic_decorators___ydb_write_threads);
-    cpy_r_r119 = CPyStatic_decorators___globals;
-    cpy_r_r120 = CPyStatics[56]; /* 'ydb_write_threads' */
-    cpy_r_r121 = CPyDict_SetItem(cpy_r_r119, cpy_r_r120, cpy_r_r118);
-    CPy_DECREF(cpy_r_r118);
-    cpy_r_r122 = cpy_r_r121 >= 0;
-    if (unlikely(!cpy_r_r122)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<module>", 30, CPyStatic_decorators___globals);
-        goto CPyL67;
+    if (unlikely(!PyBool_Check(cpy_r_r127))) {
+        CPy_TypeError("bool", cpy_r_r127); cpy_r_r128 = 2;
+    } else
+        cpy_r_r128 = cpy_r_r127 == Py_True;
+    CPy_DECREF(cpy_r_r127);
+    if (unlikely(cpy_r_r128 == 2)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 35, CPyStatic_decorators___globals);
+        goto CPyL84;
     }
-    cpy_r_r123 = CPyDef_decorators_____mypyc_lambda__0_obj();
-    if (unlikely(cpy_r_r123 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<module>", 82, CPyStatic_decorators___globals);
-        goto CPyL67;
-    }
-    CPyStatic_decorators___db_session_retry_locked = cpy_r_r123;
-    CPy_INCREF_NO_IMM(CPyStatic_decorators___db_session_retry_locked);
-    cpy_r_r124 = CPyStatic_decorators___globals;
-    cpy_r_r125 = CPyStatics[57]; /* 'db_session_retry_locked' */
-    cpy_r_r126 = CPyDict_SetItem(cpy_r_r124, cpy_r_r125, cpy_r_r123);
-    CPy_DECREF_NO_IMM(cpy_r_r123);
-    cpy_r_r127 = cpy_r_r126 >= 0;
-    if (unlikely(!cpy_r_r127)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<module>", 82, CPyStatic_decorators___globals);
-        goto CPyL67;
-    }
-    cpy_r_r128 = CPyDef_decorators_____mypyc_lambda__1_obj();
-    if (unlikely(cpy_r_r128 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<module>", 85, CPyStatic_decorators___globals);
-        goto CPyL67;
-    }
-    CPyStatic_decorators___a_sync_read_db_session = cpy_r_r128;
-    CPy_INCREF_NO_IMM(CPyStatic_decorators___a_sync_read_db_session);
-    cpy_r_r129 = CPyStatic_decorators___globals;
-    cpy_r_r130 = CPyStatics[58]; /* 'a_sync_read_db_session' */
-    cpy_r_r131 = CPyDict_SetItem(cpy_r_r129, cpy_r_r130, cpy_r_r128);
-    CPy_DECREF_NO_IMM(cpy_r_r128);
-    cpy_r_r132 = cpy_r_r131 >= 0;
-    if (unlikely(!cpy_r_r132)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<module>", 85, CPyStatic_decorators___globals);
-        goto CPyL67;
-    }
-    cpy_r_r133 = CPyDef_decorators_____mypyc_lambda__2_obj();
+    if (!cpy_r_r128) goto CPyL52;
+    cpy_r_r129 = 24;
+    goto CPyL53;
+CPyL52: ;
+    cpy_r_r129 = 8;
+CPyL53: ;
+    cpy_r_r130 = CPyStatics[61]; /* 'ydb write threads' */
+    cpy_r_r131 = CPyStatic_decorators___globals;
+    cpy_r_r132 = CPyStatics[40]; /* 'PruningThreadPoolExecutor' */
+    cpy_r_r133 = CPyDict_GetItem(cpy_r_r131, cpy_r_r132);
     if (unlikely(cpy_r_r133 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<module>", 110, CPyStatic_decorators___globals);
-        goto CPyL67;
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 34, CPyStatic_decorators___globals);
+        goto CPyL88;
     }
-    CPyStatic_decorators___db_session_cached = cpy_r_r133;
-    CPy_INCREF_NO_IMM(CPyStatic_decorators___db_session_cached);
-    cpy_r_r134 = CPyStatic_decorators___globals;
-    cpy_r_r135 = CPyStatics[59]; /* 'db_session_cached' */
-    cpy_r_r136 = CPyDict_SetItem(cpy_r_r134, cpy_r_r135, cpy_r_r133);
-    CPy_DECREF_NO_IMM(cpy_r_r133);
-    cpy_r_r137 = cpy_r_r136 >= 0;
-    if (unlikely(!cpy_r_r137)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<module>", 110, CPyStatic_decorators___globals);
-        goto CPyL67;
+    cpy_r_r134 = CPyTagged_StealAsObject(cpy_r_r129);
+    PyObject *cpy_r_r135[2] = {cpy_r_r134, cpy_r_r130};
+    cpy_r_r136 = (PyObject **)&cpy_r_r135;
+    cpy_r_r137 = PyObject_Vectorcall(cpy_r_r133, cpy_r_r136, 2, 0);
+    CPy_DECREF(cpy_r_r133);
+    if (unlikely(cpy_r_r137 == NULL)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 34, CPyStatic_decorators___globals);
+        goto CPyL89;
     }
+    CPy_DECREF(cpy_r_r134);
+    CPyStatic_decorators___ydb_write_threads = cpy_r_r137;
+    CPy_INCREF(CPyStatic_decorators___ydb_write_threads);
     cpy_r_r138 = CPyStatic_decorators___globals;
-    cpy_r_r139 = CPyStatics[9]; /* '__name__' */
-    cpy_r_r140 = CPyDict_GetItem(cpy_r_r138, cpy_r_r139);
-    if (unlikely(cpy_r_r140 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<module>", 115, CPyStatic_decorators___globals);
-        goto CPyL67;
+    cpy_r_r139 = CPyStatics[62]; /* 'ydb_write_threads' */
+    cpy_r_r140 = CPyDict_SetItem(cpy_r_r138, cpy_r_r139, cpy_r_r137);
+    CPy_DECREF(cpy_r_r137);
+    cpy_r_r141 = cpy_r_r140 >= 0;
+    if (unlikely(!cpy_r_r141)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 34, CPyStatic_decorators___globals);
+        goto CPyL84;
     }
-    if (likely(PyUnicode_Check(cpy_r_r140)))
-        cpy_r_r141 = cpy_r_r140;
+    cpy_r_r142 = CPyDef_decorators_____mypyc_lambda__0_obj();
+    if (unlikely(cpy_r_r142 == NULL)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 88, CPyStatic_decorators___globals);
+        goto CPyL84;
+    }
+    CPyStatic_decorators___db_session_retry_locked = cpy_r_r142;
+    CPy_INCREF_NO_IMM(CPyStatic_decorators___db_session_retry_locked);
+    cpy_r_r143 = CPyStatic_decorators___globals;
+    cpy_r_r144 = CPyStatics[63]; /* 'db_session_retry_locked' */
+    cpy_r_r145 = CPyDict_SetItem(cpy_r_r143, cpy_r_r144, cpy_r_r142);
+    CPy_DECREF_NO_IMM(cpy_r_r142);
+    cpy_r_r146 = cpy_r_r145 >= 0;
+    if (unlikely(!cpy_r_r146)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 88, CPyStatic_decorators___globals);
+        goto CPyL84;
+    }
+    cpy_r_r147 = CPyDef_decorators_____mypyc_lambda__1_obj();
+    if (unlikely(cpy_r_r147 == NULL)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 91, CPyStatic_decorators___globals);
+        goto CPyL84;
+    }
+    CPyStatic_decorators___a_sync_read_db_session = cpy_r_r147;
+    CPy_INCREF_NO_IMM(CPyStatic_decorators___a_sync_read_db_session);
+    cpy_r_r148 = CPyStatic_decorators___globals;
+    cpy_r_r149 = CPyStatics[64]; /* 'a_sync_read_db_session' */
+    cpy_r_r150 = CPyDict_SetItem(cpy_r_r148, cpy_r_r149, cpy_r_r147);
+    CPy_DECREF_NO_IMM(cpy_r_r147);
+    cpy_r_r151 = cpy_r_r150 >= 0;
+    if (unlikely(!cpy_r_r151)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 91, CPyStatic_decorators___globals);
+        goto CPyL84;
+    }
+    cpy_r_r152 = CPyDef_decorators_____mypyc_lambda__2_obj();
+    if (unlikely(cpy_r_r152 == NULL)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 116, CPyStatic_decorators___globals);
+        goto CPyL84;
+    }
+    CPyStatic_decorators___db_session_cached = cpy_r_r152;
+    CPy_INCREF_NO_IMM(CPyStatic_decorators___db_session_cached);
+    cpy_r_r153 = CPyStatic_decorators___globals;
+    cpy_r_r154 = CPyStatics[65]; /* 'db_session_cached' */
+    cpy_r_r155 = CPyDict_SetItem(cpy_r_r153, cpy_r_r154, cpy_r_r152);
+    CPy_DECREF_NO_IMM(cpy_r_r152);
+    cpy_r_r156 = cpy_r_r155 >= 0;
+    if (unlikely(!cpy_r_r156)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 116, CPyStatic_decorators___globals);
+        goto CPyL84;
+    }
+    cpy_r_r157 = CPyStatic_decorators___globals;
+    cpy_r_r158 = CPyStatics[9]; /* '__name__' */
+    cpy_r_r159 = CPyDict_GetItem(cpy_r_r157, cpy_r_r158);
+    if (unlikely(cpy_r_r159 == NULL)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 121, CPyStatic_decorators___globals);
+        goto CPyL84;
+    }
+    if (likely(PyUnicode_Check(cpy_r_r159)))
+        cpy_r_r160 = cpy_r_r159;
     else {
-        CPy_TypeErrorTraceback("y/_db/decorators.py", "<module>", 115, CPyStatic_decorators___globals, "str", cpy_r_r140);
-        goto CPyL67;
+        CPy_TypeErrorTraceback("y/_db/decorators.py", "<module>", 121, CPyStatic_decorators___globals, "str", cpy_r_r159);
+        goto CPyL84;
     }
-    cpy_r_r142 = CPyStatics[60]; /* '.result_count' */
-    cpy_r_r143 = CPyStr_Build(2, cpy_r_r141, cpy_r_r142);
-    CPy_DECREF(cpy_r_r141);
-    if (unlikely(cpy_r_r143 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<module>", 115, CPyStatic_decorators___globals);
-        goto CPyL67;
+    cpy_r_r161 = CPyStatics[66]; /* '.result_count' */
+    cpy_r_r162 = CPyStr_Build(2, cpy_r_r160, cpy_r_r161);
+    CPy_DECREF(cpy_r_r160);
+    if (unlikely(cpy_r_r162 == NULL)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 121, CPyStatic_decorators___globals);
+        goto CPyL84;
     }
-    cpy_r_r144 = CPyModule_logging;
-    cpy_r_r145 = CPyStatics[49]; /* 'getLogger' */
-    cpy_r_r146 = CPyObject_GetAttr(cpy_r_r144, cpy_r_r145);
-    if (unlikely(cpy_r_r146 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<module>", 115, CPyStatic_decorators___globals);
-        goto CPyL69;
-    }
-    PyObject *cpy_r_r147[1] = {cpy_r_r143};
-    cpy_r_r148 = (PyObject **)&cpy_r_r147;
-    cpy_r_r149 = PyObject_Vectorcall(cpy_r_r146, cpy_r_r148, 1, 0);
-    CPy_DECREF(cpy_r_r146);
-    if (unlikely(cpy_r_r149 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<module>", 115, CPyStatic_decorators___globals);
-        goto CPyL69;
-    }
-    CPy_DECREF(cpy_r_r143);
-    CPyStatic_decorators____result_count_logger = cpy_r_r149;
-    CPy_INCREF(CPyStatic_decorators____result_count_logger);
-    cpy_r_r150 = CPyStatic_decorators___globals;
-    cpy_r_r151 = CPyStatics[61]; /* '_result_count_logger' */
-    cpy_r_r152 = CPyDict_SetItem(cpy_r_r150, cpy_r_r151, cpy_r_r149);
-    CPy_DECREF(cpy_r_r149);
-    cpy_r_r153 = cpy_r_r152 >= 0;
-    if (unlikely(!cpy_r_r153)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<module>", 115, CPyStatic_decorators___globals);
-        goto CPyL67;
-    }
-    cpy_r_r154 = CPyStatic_decorators____result_count_logger;
-    if (likely(cpy_r_r154 != NULL)) goto CPyL54;
-    PyErr_SetString(PyExc_NameError, "value for final name \"_result_count_logger\" was not set");
-    cpy_r_r155 = 0;
-    if (unlikely(!cpy_r_r155)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<module>", 116, CPyStatic_decorators___globals);
-        goto CPyL67;
-    }
-    CPy_Unreachable();
-CPyL54: ;
-    cpy_r_r156 = CPyStatics[53]; /* 'debug' */
-    cpy_r_r157 = CPyObject_GetAttr(cpy_r_r154, cpy_r_r156);
-    if (unlikely(cpy_r_r157 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<module>", 116, CPyStatic_decorators___globals);
-        goto CPyL67;
-    }
-    CPyStatic_decorators____result_count_logger_debug = cpy_r_r157;
-    CPy_INCREF(CPyStatic_decorators____result_count_logger_debug);
-    cpy_r_r158 = CPyStatic_decorators___globals;
-    cpy_r_r159 = CPyStatics[62]; /* '_result_count_logger_debug' */
-    cpy_r_r160 = CPyDict_SetItem(cpy_r_r158, cpy_r_r159, cpy_r_r157);
-    CPy_DECREF(cpy_r_r157);
-    cpy_r_r161 = cpy_r_r160 >= 0;
-    if (unlikely(!cpy_r_r161)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<module>", 116, CPyStatic_decorators___globals);
-        goto CPyL67;
-    }
-    cpy_r_r162 = CPyStatic_decorators____result_count_logger;
-    if (likely(cpy_r_r162 != NULL)) goto CPyL59;
-    PyErr_SetString(PyExc_NameError, "value for final name \"_result_count_logger\" was not set");
-    cpy_r_r163 = 0;
-    if (unlikely(!cpy_r_r163)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<module>", 117, CPyStatic_decorators___globals);
-        goto CPyL67;
-    }
-    CPy_Unreachable();
-CPyL59: ;
-    cpy_r_r164 = CPyStatics[63]; /* 'isEnabledFor' */
-    cpy_r_r165 = CPyObject_GetAttr(cpy_r_r162, cpy_r_r164);
+    cpy_r_r163 = CPyModule_logging;
+    cpy_r_r164 = CPyStatics[52]; /* 'getLogger' */
+    cpy_r_r165 = CPyObject_GetAttr(cpy_r_r163, cpy_r_r164);
     if (unlikely(cpy_r_r165 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<module>", 117, CPyStatic_decorators___globals);
-        goto CPyL67;
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 121, CPyStatic_decorators___globals);
+        goto CPyL90;
     }
-    CPyStatic_decorators____result_count_logger_is_enabled_for = cpy_r_r165;
-    CPy_INCREF(CPyStatic_decorators____result_count_logger_is_enabled_for);
-    cpy_r_r166 = CPyStatic_decorators___globals;
-    cpy_r_r167 = CPyStatics[64]; /* '_result_count_logger_is_enabled_for' */
-    cpy_r_r168 = CPyDict_SetItem(cpy_r_r166, cpy_r_r167, cpy_r_r165);
+    PyObject *cpy_r_r166[1] = {cpy_r_r162};
+    cpy_r_r167 = (PyObject **)&cpy_r_r166;
+    cpy_r_r168 = PyObject_Vectorcall(cpy_r_r165, cpy_r_r167, 1, 0);
     CPy_DECREF(cpy_r_r165);
-    cpy_r_r169 = cpy_r_r168 >= 0;
-    if (unlikely(!cpy_r_r169)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<module>", 117, CPyStatic_decorators___globals);
-        goto CPyL67;
+    if (unlikely(cpy_r_r168 == NULL)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 121, CPyStatic_decorators___globals);
+        goto CPyL90;
     }
-    cpy_r_r170 = CPyStatics[43]; /* 'chain' */
-    cpy_r_r171 = CPyStatic_decorators___globals;
-    cpy_r_r172 = CPyStatics[43]; /* 'chain' */
-    cpy_r_r173 = CPyDict_GetItem(cpy_r_r171, cpy_r_r172);
-    if (unlikely(cpy_r_r173 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<module>", 118, CPyStatic_decorators___globals);
-        goto CPyL67;
+    CPy_DECREF(cpy_r_r162);
+    CPyStatic_decorators____result_count_logger = cpy_r_r168;
+    CPy_INCREF(CPyStatic_decorators____result_count_logger);
+    cpy_r_r169 = CPyStatic_decorators___globals;
+    cpy_r_r170 = CPyStatics[67]; /* '_result_count_logger' */
+    cpy_r_r171 = CPyDict_SetItem(cpy_r_r169, cpy_r_r170, cpy_r_r168);
+    CPy_DECREF(cpy_r_r168);
+    cpy_r_r172 = cpy_r_r171 >= 0;
+    if (unlikely(!cpy_r_r172)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 121, CPyStatic_decorators___globals);
+        goto CPyL84;
     }
-    cpy_r_r174 = CPyStatics[65]; /* 'id' */
-    cpy_r_r175 = CPyObject_GetAttr(cpy_r_r173, cpy_r_r174);
-    CPy_DECREF(cpy_r_r173);
-    if (unlikely(cpy_r_r175 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<module>", 118, CPyStatic_decorators___globals);
-        goto CPyL67;
+    cpy_r_r173 = CPyStatic_decorators____result_count_logger;
+    if (likely(cpy_r_r173 != NULL)) goto CPyL71;
+    PyErr_SetString(PyExc_NameError, "value for final name \"_result_count_logger\" was not set");
+    cpy_r_r174 = 0;
+    if (unlikely(!cpy_r_r174)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 122, CPyStatic_decorators___globals);
+        goto CPyL84;
     }
-    if (likely(PyLong_Check(cpy_r_r175)))
-        cpy_r_r176 = CPyTagged_FromObject(cpy_r_r175);
+    CPy_Unreachable();
+CPyL71: ;
+    cpy_r_r175 = CPyStatics[56]; /* 'debug' */
+    cpy_r_r176 = CPyObject_GetAttr(cpy_r_r173, cpy_r_r175);
+    if (unlikely(cpy_r_r176 == NULL)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 122, CPyStatic_decorators___globals);
+        goto CPyL84;
+    }
+    CPyStatic_decorators____result_count_logger_debug = cpy_r_r176;
+    CPy_INCREF(CPyStatic_decorators____result_count_logger_debug);
+    cpy_r_r177 = CPyStatic_decorators___globals;
+    cpy_r_r178 = CPyStatics[68]; /* '_result_count_logger_debug' */
+    cpy_r_r179 = CPyDict_SetItem(cpy_r_r177, cpy_r_r178, cpy_r_r176);
+    CPy_DECREF(cpy_r_r176);
+    cpy_r_r180 = cpy_r_r179 >= 0;
+    if (unlikely(!cpy_r_r180)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 122, CPyStatic_decorators___globals);
+        goto CPyL84;
+    }
+    cpy_r_r181 = CPyStatic_decorators____result_count_logger;
+    if (likely(cpy_r_r181 != NULL)) goto CPyL76;
+    PyErr_SetString(PyExc_NameError, "value for final name \"_result_count_logger\" was not set");
+    cpy_r_r182 = 0;
+    if (unlikely(!cpy_r_r182)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 123, CPyStatic_decorators___globals);
+        goto CPyL84;
+    }
+    CPy_Unreachable();
+CPyL76: ;
+    cpy_r_r183 = CPyStatics[69]; /* 'isEnabledFor' */
+    cpy_r_r184 = CPyObject_GetAttr(cpy_r_r181, cpy_r_r183);
+    if (unlikely(cpy_r_r184 == NULL)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 123, CPyStatic_decorators___globals);
+        goto CPyL84;
+    }
+    CPyStatic_decorators____result_count_logger_is_enabled_for = cpy_r_r184;
+    CPy_INCREF(CPyStatic_decorators____result_count_logger_is_enabled_for);
+    cpy_r_r185 = CPyStatic_decorators___globals;
+    cpy_r_r186 = CPyStatics[70]; /* '_result_count_logger_is_enabled_for' */
+    cpy_r_r187 = CPyDict_SetItem(cpy_r_r185, cpy_r_r186, cpy_r_r184);
+    CPy_DECREF(cpy_r_r184);
+    cpy_r_r188 = cpy_r_r187 >= 0;
+    if (unlikely(!cpy_r_r188)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 123, CPyStatic_decorators___globals);
+        goto CPyL84;
+    }
+    cpy_r_r189 = CPyStatics[43]; /* 'chain' */
+    cpy_r_r190 = CPyStatic_decorators___globals;
+    cpy_r_r191 = CPyStatics[43]; /* 'chain' */
+    cpy_r_r192 = CPyDict_GetItem(cpy_r_r190, cpy_r_r191);
+    if (unlikely(cpy_r_r192 == NULL)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 124, CPyStatic_decorators___globals);
+        goto CPyL84;
+    }
+    cpy_r_r193 = CPyStatics[71]; /* 'id' */
+    cpy_r_r194 = CPyObject_GetAttr(cpy_r_r192, cpy_r_r193);
+    CPy_DECREF(cpy_r_r192);
+    if (unlikely(cpy_r_r194 == NULL)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 124, CPyStatic_decorators___globals);
+        goto CPyL84;
+    }
+    if (likely(PyLong_Check(cpy_r_r194)))
+        cpy_r_r195 = CPyTagged_FromObject(cpy_r_r194);
     else {
-        CPy_TypeError("int", cpy_r_r175); cpy_r_r176 = CPY_INT_TAG;
+        CPy_TypeError("int", cpy_r_r194); cpy_r_r195 = CPY_INT_TAG;
     }
-    CPy_DECREF(cpy_r_r175);
-    if (unlikely(cpy_r_r176 == CPY_INT_TAG)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<module>", 118, CPyStatic_decorators___globals);
-        goto CPyL67;
+    CPy_DECREF(cpy_r_r194);
+    if (unlikely(cpy_r_r195 == CPY_INT_TAG)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 124, CPyStatic_decorators___globals);
+        goto CPyL84;
     }
-    CPy_INCREF(cpy_r_r170);
-    cpy_r_r177.f0 = cpy_r_r170;
-    cpy_r_r177.f1 = cpy_r_r176;
-    CPyStatic_decorators____CHAIN_INFO = cpy_r_r177;
+    CPy_INCREF(cpy_r_r189);
+    cpy_r_r196.f0 = cpy_r_r189;
+    cpy_r_r196.f1 = cpy_r_r195;
+    CPyStatic_decorators____CHAIN_INFO = cpy_r_r196;
     CPy_INCREF(CPyStatic_decorators____CHAIN_INFO.f0);
     CPyTagged_INCREF(CPyStatic_decorators____CHAIN_INFO.f1);
-    cpy_r_r178 = CPyStatic_decorators___globals;
-    cpy_r_r179 = CPyStatics[66]; /* '_CHAIN_INFO' */
-    cpy_r_r180 = PyTuple_New(2);
-    if (unlikely(cpy_r_r180 == NULL))
+    cpy_r_r197 = CPyStatic_decorators___globals;
+    cpy_r_r198 = CPyStatics[72]; /* '_CHAIN_INFO' */
+    cpy_r_r199 = PyTuple_New(2);
+    if (unlikely(cpy_r_r199 == NULL))
         CPyError_OutOfMemory();
-    PyObject *__tmp12 = cpy_r_r177.f0;
-    PyTuple_SET_ITEM(cpy_r_r180, 0, __tmp12);
-    PyObject *__tmp13 = CPyTagged_StealAsObject(cpy_r_r177.f1);
-    PyTuple_SET_ITEM(cpy_r_r180, 1, __tmp13);
-    cpy_r_r181 = CPyDict_SetItem(cpy_r_r178, cpy_r_r179, cpy_r_r180);
-    CPy_DECREF(cpy_r_r180);
-    cpy_r_r182 = cpy_r_r181 >= 0;
-    if (unlikely(!cpy_r_r182)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<module>", 118, CPyStatic_decorators___globals);
-        goto CPyL67;
+    PyObject *__tmp12 = cpy_r_r196.f0;
+    PyTuple_SET_ITEM(cpy_r_r199, 0, __tmp12);
+    PyObject *__tmp13 = CPyTagged_StealAsObject(cpy_r_r196.f1);
+    PyTuple_SET_ITEM(cpy_r_r199, 1, __tmp13);
+    cpy_r_r200 = CPyDict_SetItem(cpy_r_r197, cpy_r_r198, cpy_r_r199);
+    CPy_DECREF(cpy_r_r199);
+    cpy_r_r201 = cpy_r_r200 >= 0;
+    if (unlikely(!cpy_r_r201)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 124, CPyStatic_decorators___globals);
+        goto CPyL84;
     }
-    cpy_r_r183 = PyList_New(0);
-    if (unlikely(cpy_r_r183 == NULL)) {
-        CPy_AddTraceback("y/_db/decorators.py", "<module>", 122, CPyStatic_decorators___globals);
-        goto CPyL67;
+    cpy_r_r202 = PyList_New(0);
+    if (unlikely(cpy_r_r202 == NULL)) {
+        CPy_AddTraceback("y/_db/decorators.py", "<module>", 128, CPyStatic_decorators___globals);
+        goto CPyL84;
     }
-    CPyStatic_decorators___y____db___decorators___log_result_count___arg_names = cpy_r_r183;
+    CPyStatic_decorators___y____db___decorators___log_result_count___arg_names = cpy_r_r202;
     CPy_INCREF_NO_IMM(CPyStatic_decorators___y____db___decorators___log_result_count___arg_names);
-    CPy_DECREF_NO_IMM(cpy_r_r183);
+    CPy_DECREF_NO_IMM(cpy_r_r202);
     return 1;
-CPyL67: ;
-    cpy_r_r184 = 2;
-    return cpy_r_r184;
-CPyL68: ;
-    CPy_DecRef(cpy_r_r74);
-    goto CPyL67;
-CPyL69: ;
-    CPy_DecRef(cpy_r_r143);
-    goto CPyL67;
+CPyL84: ;
+    cpy_r_r203 = 2;
+    return cpy_r_r203;
+CPyL85: ;
+    CPy_DecRef(cpy_r_r79);
+    goto CPyL84;
+CPyL86: ;
+    CPyTagged_DecRef(cpy_r_r111);
+    goto CPyL84;
+CPyL87: ;
+    CPy_DecRef(cpy_r_r116);
+    goto CPyL84;
+CPyL88: ;
+    CPyTagged_DecRef(cpy_r_r129);
+    goto CPyL84;
+CPyL89: ;
+    CPy_DecRef(cpy_r_r134);
+    goto CPyL84;
+CPyL90: ;
+    CPy_DecRef(cpy_r_r162);
+    goto CPyL84;
 }
 static PyMethodDef stringifymodule_methods[] = {
     {"stringify_column_value", (PyCFunction)CPyPy_stringify___stringify_column_value, METH_FASTCALL | METH_KEYWORDS, NULL /* docstring */},
@@ -4129,7 +4238,7 @@ PyObject *CPyDef_stringify___stringify_column_value(PyObject *cpy_r_value, PyObj
     cpy_r_r0 = (PyObject *)&_Py_NoneStruct;
     cpy_r_r1 = cpy_r_value == cpy_r_r0;
     if (!cpy_r_r1) goto CPyL2;
-    cpy_r_r2 = CPyStatics[67]; /* 'null' */
+    cpy_r_r2 = CPyStatics[73]; /* 'null' */
     CPy_INCREF(cpy_r_r2);
     return cpy_r_r2;
 CPyL2: ;
@@ -4142,7 +4251,7 @@ CPyL2: ;
     }
     cpy_r_r6 = cpy_r_r4;
     if (!cpy_r_r6) goto CPyL25;
-    cpy_r_r7 = CPyStatics[68]; /* 'postgres' */
+    cpy_r_r7 = CPyStatics[58]; /* 'postgres' */
     cpy_r_r8 = PyUnicode_Compare(cpy_r_provider, cpy_r_r7);
     cpy_r_r9 = cpy_r_r8 == -1;
     if (!cpy_r_r9) goto CPyL7;
@@ -4157,7 +4266,7 @@ CPyL2: ;
 CPyL7: ;
     cpy_r_r13 = cpy_r_r8 == 0;
     if (!cpy_r_r13) goto CPyL12;
-    cpy_r_r14 = CPyStatics[69]; /* "'" */
+    cpy_r_r14 = CPyStatics[74]; /* "'" */
     CPy_INCREF(cpy_r_value);
     if (likely(PyBytes_Check(cpy_r_value) || PyByteArray_Check(cpy_r_value)))
         cpy_r_r15 = cpy_r_value;
@@ -4171,7 +4280,7 @@ CPyL7: ;
         CPy_AddTraceback("y/_db/utils/stringify.py", "stringify_column_value", 53, CPyStatic_stringify___globals);
         goto CPyL56;
     }
-    cpy_r_r17 = CPyStatics[70]; /* "'::bytea" */
+    cpy_r_r17 = CPyStatics[75]; /* "'::bytea" */
     cpy_r_r18 = CPyStr_Build(3, cpy_r_r14, cpy_r_r16, cpy_r_r17);
     CPy_DECREF(cpy_r_r16);
     if (unlikely(cpy_r_r18 == NULL)) {
@@ -4180,7 +4289,7 @@ CPyL7: ;
     }
     return cpy_r_r18;
 CPyL12: ;
-    cpy_r_r19 = CPyStatics[71]; /* 'sqlite' */
+    cpy_r_r19 = CPyStatics[76]; /* 'sqlite' */
     cpy_r_r20 = PyUnicode_Compare(cpy_r_provider, cpy_r_r19);
     cpy_r_r21 = cpy_r_r20 == -1;
     if (!cpy_r_r21) goto CPyL15;
@@ -4195,7 +4304,7 @@ CPyL12: ;
 CPyL15: ;
     cpy_r_r25 = cpy_r_r20 == 0;
     if (!cpy_r_r25) goto CPyL21;
-    cpy_r_r26 = CPyStatics[72]; /* "X'" */
+    cpy_r_r26 = CPyStatics[77]; /* "X'" */
     CPy_INCREF(cpy_r_value);
     if (likely(PyBytes_Check(cpy_r_value) || PyByteArray_Check(cpy_r_value)))
         cpy_r_r27 = cpy_r_value;
@@ -4203,7 +4312,7 @@ CPyL15: ;
         CPy_TypeErrorTraceback("y/_db/utils/stringify.py", "stringify_column_value", 55, CPyStatic_stringify___globals, "bytes", cpy_r_value);
         goto CPyL56;
     }
-    cpy_r_r28 = CPyStatics[73]; /* 'hex' */
+    cpy_r_r28 = CPyStatics[78]; /* 'hex' */
     PyObject *cpy_r_r29[1] = {cpy_r_r27};
     cpy_r_r30 = (PyObject **)&cpy_r_r29;
     cpy_r_r31 = PyObject_VectorcallMethod(cpy_r_r28, cpy_r_r30, 9223372036854775809ULL, 0);
@@ -4218,7 +4327,7 @@ CPyL15: ;
         CPy_TypeErrorTraceback("y/_db/utils/stringify.py", "stringify_column_value", 55, CPyStatic_stringify___globals, "str", cpy_r_r31);
         goto CPyL56;
     }
-    cpy_r_r33 = CPyStatics[69]; /* "'" */
+    cpy_r_r33 = CPyStatics[74]; /* "'" */
     cpy_r_r34 = CPyStr_Build(3, cpy_r_r26, cpy_r_r32, cpy_r_r33);
     CPy_DECREF(cpy_r_r32);
     if (unlikely(cpy_r_r34 == NULL)) {
@@ -4228,7 +4337,7 @@ CPyL15: ;
     return cpy_r_r34;
 CPyL21: ;
     cpy_r_r35 = CPyModule_builtins;
-    cpy_r_r36 = CPyStatics[74]; /* 'NotImplementedError' */
+    cpy_r_r36 = CPyStatics[79]; /* 'NotImplementedError' */
     cpy_r_r37 = CPyObject_GetAttr(cpy_r_r35, cpy_r_r36);
     if (unlikely(cpy_r_r37 == NULL)) {
         CPy_AddTraceback("y/_db/utils/stringify.py", "stringify_column_value", 56, CPyStatic_stringify___globals);
@@ -4259,7 +4368,7 @@ CPyL25: ;
     }
     cpy_r_r44 = cpy_r_r42;
     if (!cpy_r_r44) goto CPyL30;
-    cpy_r_r45 = CPyStatics[69]; /* "'" */
+    cpy_r_r45 = CPyStatics[74]; /* "'" */
     CPy_INCREF(cpy_r_value);
     if (likely(PyUnicode_Check(cpy_r_value)))
         cpy_r_r46 = cpy_r_value;
@@ -4267,7 +4376,7 @@ CPyL25: ;
         CPy_TypeErrorTraceback("y/_db/utils/stringify.py", "stringify_column_value", 58, CPyStatic_stringify___globals, "str", cpy_r_value);
         goto CPyL56;
     }
-    cpy_r_r47 = CPyStatics[69]; /* "'" */
+    cpy_r_r47 = CPyStatics[74]; /* "'" */
     cpy_r_r48 = CPyStr_Build(3, cpy_r_r45, cpy_r_r46, cpy_r_r47);
     CPy_DECREF(cpy_r_r46);
     if (unlikely(cpy_r_r48 == NULL)) {
@@ -4278,7 +4387,7 @@ CPyL25: ;
 CPyL30: ;
     cpy_r_r49 = (PyObject *)&PyLong_Type;
     cpy_r_r50 = CPyStatic_stringify___globals;
-    cpy_r_r51 = CPyStatics[75]; /* 'Decimal' */
+    cpy_r_r51 = CPyStatics[80]; /* 'Decimal' */
     cpy_r_r52 = CPyDict_GetItem(cpy_r_r50, cpy_r_r51);
     if (unlikely(cpy_r_r52 == NULL)) {
         CPy_AddTraceback("y/_db/utils/stringify.py", "stringify_column_value", 59, CPyStatic_stringify___globals);
@@ -4311,7 +4420,7 @@ CPyL30: ;
     return cpy_r_r58;
 CPyL35: ;
     cpy_r_r59 = CPyStatic_stringify___globals;
-    cpy_r_r60 = CPyStatics[76]; /* 'datetime' */
+    cpy_r_r60 = CPyStatics[81]; /* 'datetime' */
     cpy_r_r61 = CPyDict_GetItem(cpy_r_r59, cpy_r_r60);
     if (unlikely(cpy_r_r61 == NULL)) {
         CPy_AddTraceback("y/_db/utils/stringify.py", "stringify_column_value", 61, CPyStatic_stringify___globals);
@@ -4326,7 +4435,7 @@ CPyL35: ;
     }
     cpy_r_r64 = cpy_r_r62;
     if (!cpy_r_r64) goto CPyL52;
-    cpy_r_r65 = CPyStatics[69]; /* "'" */
+    cpy_r_r65 = CPyStatics[74]; /* "'" */
     cpy_r_r66 = CPyStatic_stringify___UTC;
     if (likely(cpy_r_r66 != NULL)) goto CPyL41;
     PyErr_SetString(PyExc_NameError, "value for final name \"UTC\" was not set");
@@ -4382,7 +4491,7 @@ CPyL48: ;
         CPy_TypeErrorTraceback("y/_db/utils/stringify.py", "stringify_column_value", 62, CPyStatic_stringify___globals, "str", cpy_r_r77);
         goto CPyL56;
     }
-    cpy_r_r79 = CPyStatics[69]; /* "'" */
+    cpy_r_r79 = CPyStatics[74]; /* "'" */
     cpy_r_r80 = CPyStr_Build(3, cpy_r_r65, cpy_r_r78, cpy_r_r79);
     CPy_DECREF(cpy_r_r78);
     if (unlikely(cpy_r_r80 == NULL)) {
@@ -4393,7 +4502,7 @@ CPyL48: ;
 CPyL52: ;
     cpy_r_r81 = PyObject_Type(cpy_r_value);
     cpy_r_r82 = CPyModule_builtins;
-    cpy_r_r83 = CPyStatics[74]; /* 'NotImplementedError' */
+    cpy_r_r83 = CPyStatics[79]; /* 'NotImplementedError' */
     cpy_r_r84 = CPyObject_GetAttr(cpy_r_r82, cpy_r_r83);
     if (unlikely(cpy_r_r84 == NULL)) {
         CPy_AddTraceback("y/_db/utils/stringify.py", "stringify_column_value", 64, CPyStatic_stringify___globals);
@@ -4469,8 +4578,8 @@ PyObject *CPyDef_stringify___build_row(PyObject *cpy_r_row, PyObject *cpy_r_prov
     PyObject *cpy_r_r10;
     PyObject *cpy_r_r11;
     PyObject *cpy_r_r12;
-    cpy_r_r0 = CPyStatics[77]; /* '(' */
-    cpy_r_r1 = CPyStatics[78]; /* ',' */
+    cpy_r_r0 = CPyStatics[82]; /* '(' */
+    cpy_r_r1 = CPyStatics[83]; /* ',' */
     cpy_r_r2 = PyList_New(0);
     if (unlikely(cpy_r_r2 == NULL)) {
         CPy_AddTraceback("y/_db/utils/stringify.py", "build_row", 91, CPyStatic_stringify___globals);
@@ -4510,7 +4619,7 @@ CPyL5: ;
         CPy_AddTraceback("y/_db/utils/stringify.py", "build_row", 91, CPyStatic_stringify___globals);
         goto CPyL9;
     }
-    cpy_r_r10 = CPyStatics[79]; /* ')' */
+    cpy_r_r10 = CPyStatics[84]; /* ')' */
     cpy_r_r11 = CPyStr_Build(3, cpy_r_r0, cpy_r_r9, cpy_r_r10);
     CPy_DECREF(cpy_r_r9);
     if (unlikely(cpy_r_r11 == NULL)) {
@@ -4599,7 +4708,7 @@ PyObject *CPyDef_stringify___build_query(PyObject *cpy_r_provider_name, PyObject
     PyObject **cpy_r_r40;
     PyObject *cpy_r_r41;
     PyObject *cpy_r_r42;
-    cpy_r_r0 = CPyStatics[78]; /* ',' */
+    cpy_r_r0 = CPyStatics[83]; /* ',' */
     cpy_r_r1 = PyList_New(0);
     if (unlikely(cpy_r_r1 == NULL)) {
         CPy_AddTraceback("y/_db/utils/stringify.py", "build_query", 97, CPyStatic_stringify___globals);
@@ -4639,7 +4748,7 @@ CPyL5: ;
         CPy_AddTraceback("y/_db/utils/stringify.py", "build_query", 97, CPyStatic_stringify___globals);
         goto CPyL25;
     }
-    cpy_r_r9 = CPyStatics[71]; /* 'sqlite' */
+    cpy_r_r9 = CPyStatics[76]; /* 'sqlite' */
     cpy_r_r10 = PyUnicode_Compare(cpy_r_provider_name, cpy_r_r9);
     cpy_r_r11 = cpy_r_r10 == -1;
     if (!cpy_r_r11) goto CPyL10;
@@ -4654,15 +4763,15 @@ CPyL5: ;
 CPyL10: ;
     cpy_r_r15 = cpy_r_r10 == 0;
     if (!cpy_r_r15) goto CPyL14;
-    cpy_r_r16 = CPyStatics[80]; /* 'insert or ignore into ' */
-    cpy_r_r17 = CPyStatics[81]; /* ' (' */
-    cpy_r_r18 = CPyStatics[78]; /* ',' */
+    cpy_r_r16 = CPyStatics[85]; /* 'insert or ignore into ' */
+    cpy_r_r17 = CPyStatics[86]; /* ' (' */
+    cpy_r_r18 = CPyStatics[83]; /* ',' */
     cpy_r_r19 = PyUnicode_Join(cpy_r_r18, cpy_r_columns);
     if (unlikely(cpy_r_r19 == NULL)) {
         CPy_AddTraceback("y/_db/utils/stringify.py", "build_query", 99, CPyStatic_stringify___globals);
         goto CPyL29;
     }
-    cpy_r_r20 = CPyStatics[82]; /* ') values ' */
+    cpy_r_r20 = CPyStatics[87]; /* ') values ' */
     cpy_r_r21 = CPyStr_Build(6, cpy_r_r16, cpy_r_entity_name, cpy_r_r17, cpy_r_r19, cpy_r_r20, cpy_r_r8);
     CPy_DECREF(cpy_r_r19);
     CPy_DECREF(cpy_r_r8);
@@ -4672,7 +4781,7 @@ CPyL10: ;
     }
     return cpy_r_r21;
 CPyL14: ;
-    cpy_r_r22 = CPyStatics[68]; /* 'postgres' */
+    cpy_r_r22 = CPyStatics[58]; /* 'postgres' */
     cpy_r_r23 = PyUnicode_Compare(cpy_r_provider_name, cpy_r_r22);
     cpy_r_r24 = cpy_r_r23 == -1;
     if (!cpy_r_r24) goto CPyL17;
@@ -4687,16 +4796,16 @@ CPyL14: ;
 CPyL17: ;
     cpy_r_r28 = cpy_r_r23 == 0;
     if (!cpy_r_r28) goto CPyL30;
-    cpy_r_r29 = CPyStatics[83]; /* 'insert into ' */
-    cpy_r_r30 = CPyStatics[81]; /* ' (' */
-    cpy_r_r31 = CPyStatics[78]; /* ',' */
+    cpy_r_r29 = CPyStatics[88]; /* 'insert into ' */
+    cpy_r_r30 = CPyStatics[86]; /* ' (' */
+    cpy_r_r31 = CPyStatics[83]; /* ',' */
     cpy_r_r32 = PyUnicode_Join(cpy_r_r31, cpy_r_columns);
     if (unlikely(cpy_r_r32 == NULL)) {
         CPy_AddTraceback("y/_db/utils/stringify.py", "build_query", 102, CPyStatic_stringify___globals);
         goto CPyL29;
     }
-    cpy_r_r33 = CPyStatics[82]; /* ') values ' */
-    cpy_r_r34 = CPyStatics[84]; /* ' on conflict do nothing' */
+    cpy_r_r33 = CPyStatics[87]; /* ') values ' */
+    cpy_r_r34 = CPyStatics[89]; /* ' on conflict do nothing' */
     cpy_r_r35 = CPyStr_Build(7, cpy_r_r29, cpy_r_entity_name, cpy_r_r30, cpy_r_r32, cpy_r_r33, cpy_r_r8, cpy_r_r34);
     CPy_DECREF(cpy_r_r32);
     CPy_DECREF(cpy_r_r8);
@@ -4707,7 +4816,7 @@ CPyL17: ;
     return cpy_r_r35;
 CPyL21: ;
     cpy_r_r36 = CPyModule_builtins;
-    cpy_r_r37 = CPyStatics[74]; /* 'NotImplementedError' */
+    cpy_r_r37 = CPyStatics[79]; /* 'NotImplementedError' */
     cpy_r_r38 = CPyObject_GetAttr(cpy_r_r36, cpy_r_r37);
     if (unlikely(cpy_r_r38 == NULL)) {
         CPy_AddTraceback("y/_db/utils/stringify.py", "build_query", 105, CPyStatic_stringify___globals);
@@ -4842,8 +4951,8 @@ char CPyDef_stringify_____top_level__(void) {
     CPy_INCREF(CPyModule_builtins);
     CPy_DECREF(cpy_r_r4);
 CPyL3: ;
-    cpy_r_r5 = CPyStatics[500]; /* ('datetime', 'timezone') */
-    cpy_r_r6 = CPyStatics[76]; /* 'datetime' */
+    cpy_r_r5 = CPyStatics[503]; /* ('datetime', 'timezone') */
+    cpy_r_r6 = CPyStatics[81]; /* 'datetime' */
     cpy_r_r7 = CPyStatic_stringify___globals;
     cpy_r_r8 = CPyImport_ImportFromMany(cpy_r_r6, cpy_r_r5, cpy_r_r5, cpy_r_r7);
     if (unlikely(cpy_r_r8 == NULL)) {
@@ -4853,8 +4962,8 @@ CPyL3: ;
     CPyModule_datetime = cpy_r_r8;
     CPy_INCREF(CPyModule_datetime);
     CPy_DECREF(cpy_r_r8);
-    cpy_r_r9 = CPyStatics[501]; /* ('Decimal',) */
-    cpy_r_r10 = CPyStatics[86]; /* 'decimal' */
+    cpy_r_r9 = CPyStatics[504]; /* ('Decimal',) */
+    cpy_r_r10 = CPyStatics[91]; /* 'decimal' */
     cpy_r_r11 = CPyStatic_stringify___globals;
     cpy_r_r12 = CPyImport_ImportFromMany(cpy_r_r10, cpy_r_r9, cpy_r_r9, cpy_r_r11);
     if (unlikely(cpy_r_r12 == NULL)) {
@@ -4864,7 +4973,7 @@ CPyL3: ;
     CPyModule_decimal = cpy_r_r12;
     CPy_INCREF(CPyModule_decimal);
     CPy_DECREF(cpy_r_r12);
-    cpy_r_r13 = CPyStatics[502]; /* ('Any', 'Final', 'Iterable') */
+    cpy_r_r13 = CPyStatics[505]; /* ('Any', 'Final', 'Iterable') */
     cpy_r_r14 = CPyStatics[37]; /* 'typing' */
     cpy_r_r15 = CPyStatic_stringify___globals;
     cpy_r_r16 = CPyImport_ImportFromMany(cpy_r_r14, cpy_r_r13, cpy_r_r13, cpy_r_r15);
@@ -4876,13 +4985,13 @@ CPyL3: ;
     CPy_INCREF(CPyModule_typing);
     CPy_DECREF(cpy_r_r16);
     cpy_r_r17 = CPyStatic_stringify___globals;
-    cpy_r_r18 = CPyStatics[85]; /* 'timezone' */
+    cpy_r_r18 = CPyStatics[90]; /* 'timezone' */
     cpy_r_r19 = CPyDict_GetItem(cpy_r_r17, cpy_r_r18);
     if (unlikely(cpy_r_r19 == NULL)) {
         CPy_AddTraceback("y/_db/utils/stringify.py", "<module>", 6, CPyStatic_stringify___globals);
         goto CPyL16;
     }
-    cpy_r_r20 = CPyStatics[88]; /* 'utc' */
+    cpy_r_r20 = CPyStatics[93]; /* 'utc' */
     cpy_r_r21 = CPyObject_GetAttr(cpy_r_r19, cpy_r_r20);
     CPy_DECREF(cpy_r_r19);
     if (unlikely(cpy_r_r21 == NULL)) {
@@ -4892,7 +5001,7 @@ CPyL3: ;
     CPyStatic_stringify___UTC = cpy_r_r21;
     CPy_INCREF(CPyStatic_stringify___UTC);
     cpy_r_r22 = CPyStatic_stringify___globals;
-    cpy_r_r23 = CPyStatics[89]; /* 'UTC' */
+    cpy_r_r23 = CPyStatics[94]; /* 'UTC' */
     cpy_r_r24 = CPyDict_SetItem(cpy_r_r22, cpy_r_r23, cpy_r_r21);
     CPy_DECREF(cpy_r_r21);
     cpy_r_r25 = cpy_r_r24 >= 0;
@@ -4901,13 +5010,13 @@ CPyL3: ;
         goto CPyL16;
     }
     cpy_r_r26 = CPyStatic_stringify___globals;
-    cpy_r_r27 = CPyStatics[76]; /* 'datetime' */
+    cpy_r_r27 = CPyStatics[81]; /* 'datetime' */
     cpy_r_r28 = CPyDict_GetItem(cpy_r_r26, cpy_r_r27);
     if (unlikely(cpy_r_r28 == NULL)) {
         CPy_AddTraceback("y/_db/utils/stringify.py", "<module>", 8, CPyStatic_stringify___globals);
         goto CPyL16;
     }
-    cpy_r_r29 = CPyStatics[90]; /* 'astimezone' */
+    cpy_r_r29 = CPyStatics[95]; /* 'astimezone' */
     cpy_r_r30 = CPyObject_GetAttr(cpy_r_r28, cpy_r_r29);
     CPy_DECREF(cpy_r_r28);
     if (unlikely(cpy_r_r30 == NULL)) {
@@ -4917,7 +5026,7 @@ CPyL3: ;
     CPyStatic_stringify___astimezone = cpy_r_r30;
     CPy_INCREF(CPyStatic_stringify___astimezone);
     cpy_r_r31 = CPyStatic_stringify___globals;
-    cpy_r_r32 = CPyStatics[90]; /* 'astimezone' */
+    cpy_r_r32 = CPyStatics[95]; /* 'astimezone' */
     cpy_r_r33 = CPyDict_SetItem(cpy_r_r31, cpy_r_r32, cpy_r_r30);
     CPy_DECREF(cpy_r_r30);
     cpy_r_r34 = cpy_r_r33 >= 0;
@@ -4926,13 +5035,13 @@ CPyL3: ;
         goto CPyL16;
     }
     cpy_r_r35 = CPyStatic_stringify___globals;
-    cpy_r_r36 = CPyStatics[76]; /* 'datetime' */
+    cpy_r_r36 = CPyStatics[81]; /* 'datetime' */
     cpy_r_r37 = CPyDict_GetItem(cpy_r_r35, cpy_r_r36);
     if (unlikely(cpy_r_r37 == NULL)) {
         CPy_AddTraceback("y/_db/utils/stringify.py", "<module>", 9, CPyStatic_stringify___globals);
         goto CPyL16;
     }
-    cpy_r_r38 = CPyStatics[91]; /* 'isoformat' */
+    cpy_r_r38 = CPyStatics[96]; /* 'isoformat' */
     cpy_r_r39 = CPyObject_GetAttr(cpy_r_r37, cpy_r_r38);
     CPy_DECREF(cpy_r_r37);
     if (unlikely(cpy_r_r39 == NULL)) {
@@ -4942,7 +5051,7 @@ CPyL3: ;
     CPyStatic_stringify___isoformat = cpy_r_r39;
     CPy_INCREF(CPyStatic_stringify___isoformat);
     cpy_r_r40 = CPyStatic_stringify___globals;
-    cpy_r_r41 = CPyStatics[91]; /* 'isoformat' */
+    cpy_r_r41 = CPyStatics[96]; /* 'isoformat' */
     cpy_r_r42 = CPyDict_SetItem(cpy_r_r40, cpy_r_r41, cpy_r_r39);
     CPy_DECREF(cpy_r_r39);
     cpy_r_r43 = cpy_r_r42 >= 0;
@@ -5168,14 +5277,14 @@ CPyL3: ;
     cpy_r_r7 = (void *)&cpy_r_r6;
     int64_t cpy_r_r8[1] = {28};
     cpy_r_r9 = (void *)&cpy_r_r8;
-    cpy_r_r10 = CPyStatics[504]; /* (('errno', 'errno', 'errno'),) */
+    cpy_r_r10 = CPyStatics[507]; /* (('errno', 'errno', 'errno'),) */
     cpy_r_r11 = CPyStatic_config___globals;
-    cpy_r_r12 = CPyStatics[93]; /* 'y/_db/config.py' */
+    cpy_r_r12 = CPyStatics[98]; /* 'y/_db/config.py' */
     cpy_r_r13 = CPyStatics[31]; /* '<module>' */
     cpy_r_r14 = CPyImport_ImportMany(cpy_r_r10, cpy_r_r7, cpy_r_r11, cpy_r_r12, cpy_r_r13, cpy_r_r9);
     if (!cpy_r_r14) goto CPyL97;
-    cpy_r_r15 = CPyStatics[505]; /* ('mkdir', 'path') */
-    cpy_r_r16 = CPyStatics[96]; /* 'os' */
+    cpy_r_r15 = CPyStatics[508]; /* ('mkdir', 'path') */
+    cpy_r_r16 = CPyStatics[101]; /* 'os' */
     cpy_r_r17 = CPyStatic_config___globals;
     cpy_r_r18 = CPyImport_ImportFromMany(cpy_r_r16, cpy_r_r15, cpy_r_r15, cpy_r_r17);
     if (unlikely(cpy_r_r18 == NULL)) {
@@ -5185,7 +5294,7 @@ CPyL3: ;
     CPyModule_os = cpy_r_r18;
     CPy_INCREF(CPyModule_os);
     CPy_DECREF(cpy_r_r18);
-    cpy_r_r19 = CPyStatics[506]; /* ('Final',) */
+    cpy_r_r19 = CPyStatics[509]; /* ('Final',) */
     cpy_r_r20 = CPyStatics[37]; /* 'typing' */
     cpy_r_r21 = CPyStatic_config___globals;
     cpy_r_r22 = CPyImport_ImportFromMany(cpy_r_r20, cpy_r_r19, cpy_r_r19, cpy_r_r21);
@@ -5196,9 +5305,9 @@ CPyL3: ;
     CPyModule_typing = cpy_r_r22;
     CPy_INCREF(CPyModule_typing);
     CPy_DECREF(cpy_r_r22);
-    cpy_r_r23 = CPyStatics[507]; /* ('ENVIRONMENT_VARIABLES',) */
-    cpy_r_r24 = CPyStatics[508]; /* ('ENVS',) */
-    cpy_r_r25 = CPyStatics[99]; /* 'y' */
+    cpy_r_r23 = CPyStatics[501]; /* ('ENVIRONMENT_VARIABLES',) */
+    cpy_r_r24 = CPyStatics[502]; /* ('ENVS',) */
+    cpy_r_r25 = CPyStatics[48]; /* 'y' */
     cpy_r_r26 = CPyStatic_config___globals;
     cpy_r_r27 = CPyImport_ImportFromMany(cpy_r_r25, cpy_r_r23, cpy_r_r24, cpy_r_r26);
     if (unlikely(cpy_r_r27 == NULL)) {
@@ -5208,15 +5317,15 @@ CPyL3: ;
     CPyModule_y = cpy_r_r27;
     CPy_INCREF(CPyModule_y);
     CPy_DECREF(cpy_r_r27);
-    cpy_r_r28 = CPyStatics[100]; /* '~' */
+    cpy_r_r28 = CPyStatics[102]; /* '~' */
     cpy_r_r29 = CPyStatic_config___globals;
-    cpy_r_r30 = CPyStatics[95]; /* 'path' */
+    cpy_r_r30 = CPyStatics[100]; /* 'path' */
     cpy_r_r31 = CPyDict_GetItem(cpy_r_r29, cpy_r_r30);
     if (unlikely(cpy_r_r31 == NULL)) {
         CPy_AddTraceback("y/_db/config.py", "<module>", 35, CPyStatic_config___globals);
         goto CPyL97;
     }
-    cpy_r_r32 = CPyStatics[101]; /* 'expanduser' */
+    cpy_r_r32 = CPyStatics[103]; /* 'expanduser' */
     cpy_r_r33 = CPyObject_GetAttr(cpy_r_r31, cpy_r_r32);
     CPy_DECREF(cpy_r_r31);
     if (unlikely(cpy_r_r33 == NULL)) {
@@ -5237,7 +5346,7 @@ CPyL3: ;
         CPy_TypeErrorTraceback("y/_db/config.py", "<module>", 35, CPyStatic_config___globals, "str", cpy_r_r36);
         goto CPyL97;
     }
-    cpy_r_r38 = CPyStatics[102]; /* '/.ypricemagic' */
+    cpy_r_r38 = CPyStatics[104]; /* '/.ypricemagic' */
     cpy_r_r39 = CPyStr_Build(2, cpy_r_r37, cpy_r_r38);
     CPy_DECREF(cpy_r_r37);
     if (unlikely(cpy_r_r39 == NULL)) {
@@ -5247,7 +5356,7 @@ CPyL3: ;
     CPyStatic_config___DEFAULT_SQLITE_DIR = cpy_r_r39;
     CPy_INCREF(CPyStatic_config___DEFAULT_SQLITE_DIR);
     cpy_r_r40 = CPyStatic_config___globals;
-    cpy_r_r41 = CPyStatics[103]; /* 'DEFAULT_SQLITE_DIR' */
+    cpy_r_r41 = CPyStatics[105]; /* 'DEFAULT_SQLITE_DIR' */
     cpy_r_r42 = CPyDict_SetItem(cpy_r_r40, cpy_r_r41, cpy_r_r39);
     CPy_DECREF(cpy_r_r39);
     cpy_r_r43 = cpy_r_r42 >= 0;
@@ -5273,7 +5382,7 @@ CPyL16: ;
     CPyStatic_config___db_provider = cpy_r_r46;
     CPy_INCREF(CPyStatic_config___db_provider);
     cpy_r_r47 = CPyStatic_config___globals;
-    cpy_r_r48 = CPyStatics[104]; /* 'db_provider' */
+    cpy_r_r48 = CPyStatics[106]; /* 'db_provider' */
     cpy_r_r49 = CPyDict_SetItem(cpy_r_r47, cpy_r_r48, cpy_r_r46);
     CPy_DECREF(cpy_r_r46);
     cpy_r_r50 = cpy_r_r49 >= 0;
@@ -5291,7 +5400,7 @@ CPyL16: ;
     }
     CPy_Unreachable();
 CPyL21: ;
-    cpy_r_r53 = CPyStatics[71]; /* 'sqlite' */
+    cpy_r_r53 = CPyStatics[76]; /* 'sqlite' */
     cpy_r_r54 = PyUnicode_Compare(cpy_r_r51, cpy_r_r53);
     cpy_r_r55 = cpy_r_r54 == -1;
     if (!cpy_r_r55) goto CPyL24;
@@ -5316,7 +5425,7 @@ CPyL24: ;
     }
     CPy_Unreachable();
 CPyL28: ;
-    cpy_r_r62 = CPyStatics[105]; /* '_using_default' */
+    cpy_r_r62 = CPyStatics[107]; /* '_using_default' */
     cpy_r_r63 = CPyObject_GetAttr(cpy_r_r60, cpy_r_r62);
     if (unlikely(cpy_r_r63 == NULL)) {
         CPy_AddTraceback("y/_db/config.py", "<module>", 40, CPyStatic_config___globals);
@@ -5343,7 +5452,7 @@ CPyL28: ;
     CPy_Unreachable();
 CPyL34: ;
     cpy_r_r67 = CPyStatic_config___globals;
-    cpy_r_r68 = CPyStatics[94]; /* 'mkdir' */
+    cpy_r_r68 = CPyStatics[99]; /* 'mkdir' */
     cpy_r_r69 = CPyDict_GetItem(cpy_r_r67, cpy_r_r68);
     if (unlikely(cpy_r_r69 == NULL)) {
         CPy_AddTraceback("y/_db/config.py", "<module>", 42, CPyStatic_config___globals);
@@ -5360,7 +5469,7 @@ CPyL34: ;
 CPyL36: ;
     cpy_r_r73 = CPy_CatchError();
     cpy_r_r74 = CPyModule_builtins;
-    cpy_r_r75 = CPyStatics[106]; /* 'OSError' */
+    cpy_r_r75 = CPyStatics[108]; /* 'OSError' */
     cpy_r_r76 = CPyObject_GetAttr(cpy_r_r74, cpy_r_r75);
     if (unlikely(cpy_r_r76 == NULL)) {
         CPy_AddTraceback("y/_db/config.py", "<module>", 43, CPyStatic_config___globals);
@@ -5370,7 +5479,7 @@ CPyL36: ;
     CPy_DecRef(cpy_r_r76);
     if (!cpy_r_r77) goto CPyL49;
     cpy_r_r78 = CPyStatic_config___globals;
-    cpy_r_r79 = CPyStatics[107]; /* 'e' */
+    cpy_r_r79 = CPyStatics[109]; /* 'e' */
     cpy_r_r80 = CPy_GetExcValue();
     cpy_r_r81 = CPyDict_SetItem(cpy_r_r78, cpy_r_r79, cpy_r_r80);
     CPy_DecRef(cpy_r_r80);
@@ -5380,13 +5489,13 @@ CPyL36: ;
         goto CPyL52;
     }
     cpy_r_r83 = CPyStatic_config___globals;
-    cpy_r_r84 = CPyStatics[107]; /* 'e' */
+    cpy_r_r84 = CPyStatics[109]; /* 'e' */
     cpy_r_r85 = CPyDict_GetItem(cpy_r_r83, cpy_r_r84);
     if (unlikely(cpy_r_r85 == NULL)) {
         CPy_AddTraceback("y/_db/config.py", "<module>", 44, CPyStatic_config___globals);
         goto CPyL52;
     }
-    cpy_r_r86 = CPyStatics[92]; /* 'errno' */
+    cpy_r_r86 = CPyStatics[97]; /* 'errno' */
     cpy_r_r87 = CPyObject_GetAttr(cpy_r_r85, cpy_r_r86);
     CPy_DecRef(cpy_r_r85);
     if (unlikely(cpy_r_r87 == NULL)) {
@@ -5409,7 +5518,7 @@ CPyL36: ;
     goto CPyL52;
 __LL16: ;
     cpy_r_r89 = CPyModule_errno;
-    cpy_r_r90 = CPyStatics[108]; /* 'EEXIST' */
+    cpy_r_r90 = CPyStatics[110]; /* 'EEXIST' */
     cpy_r_r91 = CPyObject_GetAttr(cpy_r_r89, cpy_r_r90);
     if (unlikely(cpy_r_r91 == NULL)) {
         CPy_AddTraceback("y/_db/config.py", "<module>", 44, CPyStatic_config___globals);
@@ -5473,7 +5582,7 @@ CPyL52: ;
     if (!cpy_r_r96) goto CPyL97;
     CPy_Unreachable();
 CPyL54: ;
-    cpy_r_r97 = CPyStatics[109]; /* 'provider' */
+    cpy_r_r97 = CPyStatics[111]; /* 'provider' */
     cpy_r_r98 = CPyStatic_config___db_provider;
     if (likely(cpy_r_r98 != NULL)) goto CPyL57;
     PyErr_SetString(PyExc_NameError, "value for final name \"db_provider\" was not set");
@@ -5484,7 +5593,7 @@ CPyL54: ;
     }
     CPy_Unreachable();
 CPyL57: ;
-    cpy_r_r100 = CPyStatics[110]; /* 'filename' */
+    cpy_r_r100 = CPyStatics[112]; /* 'filename' */
     cpy_r_r101 = CPyStatic_ENVIRONMENT_VARIABLES___SQLITE_PATH;
     if (likely(cpy_r_r101 != NULL)) goto CPyL60;
     PyErr_SetString(PyExc_NameError, "value for final name \"SQLITE_PATH\" was not set");
@@ -5500,7 +5609,7 @@ CPyL60: ;
         CPy_AddTraceback("y/_db/config.py", "<module>", 49, CPyStatic_config___globals);
         goto CPyL97;
     }
-    cpy_r_r104 = CPyStatics[111]; /* 'create_db' */
+    cpy_r_r104 = CPyStatics[113]; /* 'create_db' */
     cpy_r_r105 = 1 ? Py_True : Py_False;
     cpy_r_r106 = CPyDict_Build(3, cpy_r_r97, cpy_r_r98, cpy_r_r100, cpy_r_r103, cpy_r_r104, cpy_r_r105);
     CPy_DECREF(cpy_r_r103);
@@ -5509,7 +5618,7 @@ CPyL60: ;
         goto CPyL97;
     }
     cpy_r_r107 = CPyStatic_config___globals;
-    cpy_r_r108 = CPyStatics[112]; /* 'connection_settings' */
+    cpy_r_r108 = CPyStatics[114]; /* 'connection_settings' */
     cpy_r_r109 = CPyDict_SetItem(cpy_r_r107, cpy_r_r108, cpy_r_r106);
     CPy_DECREF(cpy_r_r106);
     cpy_r_r110 = cpy_r_r109 >= 0;
@@ -5519,7 +5628,7 @@ CPyL60: ;
     } else
         goto CPyL96;
 CPyL63: ;
-    cpy_r_r111 = CPyStatics[109]; /* 'provider' */
+    cpy_r_r111 = CPyStatics[111]; /* 'provider' */
     cpy_r_r112 = CPyStatic_config___db_provider;
     if (likely(cpy_r_r112 != NULL)) goto CPyL66;
     PyErr_SetString(PyExc_NameError, "value for final name \"db_provider\" was not set");
@@ -5530,7 +5639,7 @@ CPyL63: ;
     }
     CPy_Unreachable();
 CPyL66: ;
-    cpy_r_r114 = CPyStatics[113]; /* 'host' */
+    cpy_r_r114 = CPyStatics[115]; /* 'host' */
     cpy_r_r115 = CPyStatic_ENVIRONMENT_VARIABLES___DB_HOST;
     if (likely(cpy_r_r115 != NULL)) goto CPyL69;
     PyErr_SetString(PyExc_NameError, "value for final name \"DB_HOST\" was not set");
@@ -5546,7 +5655,7 @@ CPyL69: ;
         CPy_AddTraceback("y/_db/config.py", "<module>", 55, CPyStatic_config___globals);
         goto CPyL97;
     }
-    cpy_r_r118 = CPyStatics[114]; /* 'user' */
+    cpy_r_r118 = CPyStatics[116]; /* 'user' */
     cpy_r_r119 = CPyStatic_ENVIRONMENT_VARIABLES___DB_USER;
     if (unlikely(cpy_r_r119 == NULL)) {
         goto CPyL102;
@@ -5566,7 +5675,7 @@ CPyL73: ;
         CPy_AddTraceback("y/_db/config.py", "<module>", 56, CPyStatic_config___globals);
         goto CPyL103;
     }
-    cpy_r_r122 = CPyStatics[115]; /* 'password' */
+    cpy_r_r122 = CPyStatics[117]; /* 'password' */
     cpy_r_r123 = CPyStatic_ENVIRONMENT_VARIABLES___DB_PASSWORD;
     if (unlikely(cpy_r_r123 == NULL)) {
         goto CPyL104;
@@ -5586,7 +5695,7 @@ CPyL77: ;
         CPy_AddTraceback("y/_db/config.py", "<module>", 57, CPyStatic_config___globals);
         goto CPyL105;
     }
-    cpy_r_r126 = CPyStatics[116]; /* 'database' */
+    cpy_r_r126 = CPyStatics[118]; /* 'database' */
     cpy_r_r127 = CPyStatic_ENVIRONMENT_VARIABLES___DB_DATABASE;
     if (unlikely(cpy_r_r127 == NULL)) {
         goto CPyL106;
@@ -5616,7 +5725,7 @@ CPyL81: ;
         goto CPyL97;
     }
     cpy_r_r131 = CPyStatic_config___globals;
-    cpy_r_r132 = CPyStatics[112]; /* 'connection_settings' */
+    cpy_r_r132 = CPyStatics[114]; /* 'connection_settings' */
     cpy_r_r133 = CPyDict_SetItem(cpy_r_r131, cpy_r_r132, cpy_r_r130);
     CPy_DECREF(cpy_r_r130);
     cpy_r_r134 = cpy_r_r133 >= 0;
@@ -5661,7 +5770,7 @@ CPyL92: ;
         goto CPyL97;
     }
     cpy_r_r146 = CPyStatic_config___globals;
-    cpy_r_r147 = CPyStatics[112]; /* 'connection_settings' */
+    cpy_r_r147 = CPyStatics[114]; /* 'connection_settings' */
     cpy_r_r148 = CPyDict_GetItem(cpy_r_r146, cpy_r_r147);
     if (unlikely(cpy_r_r148 == NULL)) {
         CPy_AddTraceback("y/_db/config.py", "<module>", 61, CPyStatic_config___globals);
@@ -5673,7 +5782,7 @@ CPyL92: ;
         CPy_TypeErrorTraceback("y/_db/config.py", "<module>", 61, CPyStatic_config___globals, "dict", cpy_r_r148);
         goto CPyL108;
     }
-    cpy_r_r150 = CPyStatics[117]; /* 'port' */
+    cpy_r_r150 = CPyStatics[119]; /* 'port' */
     cpy_r_r151 = CPyDict_SetItem(cpy_r_r149, cpy_r_r150, cpy_r_r145);
     CPy_DECREF(cpy_r_r149);
     CPy_DECREF(cpy_r_r145);
@@ -6053,8 +6162,8 @@ char CPyDef_ENVIRONMENT_VARIABLES_____top_level__(void) {
     CPy_INCREF(CPyModule_builtins);
     CPy_DECREF(cpy_r_r4);
 CPyL3: ;
-    cpy_r_r5 = CPyStatics[509]; /* ('path',) */
-    cpy_r_r6 = CPyStatics[96]; /* 'os' */
+    cpy_r_r5 = CPyStatics[510]; /* ('path',) */
+    cpy_r_r6 = CPyStatics[101]; /* 'os' */
     cpy_r_r7 = CPyStatic_ENVIRONMENT_VARIABLES___globals;
     cpy_r_r8 = CPyImport_ImportFromMany(cpy_r_r6, cpy_r_r5, cpy_r_r5, cpy_r_r7);
     if (unlikely(cpy_r_r8 == NULL)) {
@@ -6064,7 +6173,7 @@ CPyL3: ;
     CPyModule_os = cpy_r_r8;
     CPy_INCREF(CPyModule_os);
     CPy_DECREF(cpy_r_r8);
-    cpy_r_r9 = CPyStatics[506]; /* ('Final',) */
+    cpy_r_r9 = CPyStatics[509]; /* ('Final',) */
     cpy_r_r10 = CPyStatics[37]; /* 'typing' */
     cpy_r_r11 = CPyStatic_ENVIRONMENT_VARIABLES___globals;
     cpy_r_r12 = CPyImport_ImportFromMany(cpy_r_r10, cpy_r_r9, cpy_r_r9, cpy_r_r11);
@@ -6075,8 +6184,8 @@ CPyL3: ;
     CPyModule_typing = cpy_r_r12;
     CPy_INCREF(CPyModule_typing);
     CPy_DECREF(cpy_r_r12);
-    cpy_r_r13 = CPyStatics[510]; /* ('EnvVarFactory', 'create_env') */
-    cpy_r_r14 = CPyStatics[120]; /* 'typed_envs' */
+    cpy_r_r13 = CPyStatics[511]; /* ('EnvVarFactory', 'create_env') */
+    cpy_r_r14 = CPyStatics[122]; /* 'typed_envs' */
     cpy_r_r15 = CPyStatic_ENVIRONMENT_VARIABLES___globals;
     cpy_r_r16 = CPyImport_ImportFromMany(cpy_r_r14, cpy_r_r13, cpy_r_r13, cpy_r_r15);
     if (unlikely(cpy_r_r16 == NULL)) {
@@ -6086,9 +6195,9 @@ CPyL3: ;
     CPyModule_typed_envs = cpy_r_r16;
     CPy_INCREF(CPyModule_typed_envs);
     CPy_DECREF(cpy_r_r16);
-    cpy_r_r17 = CPyStatics[121]; /* 'YPRICEMAGIC' */
+    cpy_r_r17 = CPyStatics[123]; /* 'YPRICEMAGIC' */
     cpy_r_r18 = CPyStatic_ENVIRONMENT_VARIABLES___globals;
-    cpy_r_r19 = CPyStatics[118]; /* 'EnvVarFactory' */
+    cpy_r_r19 = CPyStatics[120]; /* 'EnvVarFactory' */
     cpy_r_r20 = CPyDict_GetItem(cpy_r_r18, cpy_r_r19);
     if (unlikely(cpy_r_r20 == NULL)) {
         CPy_AddTraceback("y/ENVIRONMENT_VARIABLES.py", "<module>", 7, CPyStatic_ENVIRONMENT_VARIABLES___globals);
@@ -6105,7 +6214,7 @@ CPyL3: ;
     CPyStatic_ENVIRONMENT_VARIABLES____envs = cpy_r_r23;
     CPy_INCREF(CPyStatic_ENVIRONMENT_VARIABLES____envs);
     cpy_r_r24 = CPyStatic_ENVIRONMENT_VARIABLES___globals;
-    cpy_r_r25 = CPyStatics[122]; /* '_envs' */
+    cpy_r_r25 = CPyStatics[124]; /* '_envs' */
     cpy_r_r26 = CPyDict_SetItem(cpy_r_r24, cpy_r_r25, cpy_r_r23);
     CPy_DECREF(cpy_r_r23);
     cpy_r_r27 = cpy_r_r26 >= 0;
@@ -6123,14 +6232,14 @@ CPyL3: ;
     }
     CPy_Unreachable();
 CPyL12: ;
-    cpy_r_r30 = CPyStatics[123]; /* 'CACHE_TTL' */
+    cpy_r_r30 = CPyStatics[125]; /* 'CACHE_TTL' */
     cpy_r_r31 = (PyObject *)&PyLong_Type;
-    cpy_r_r32 = CPyStatics[119]; /* 'create_env' */
-    cpy_r_r33 = CPyStatics[468]; /* 3600 */
+    cpy_r_r32 = CPyStatics[121]; /* 'create_env' */
+    cpy_r_r33 = CPyStatics[469]; /* 3600 */
     cpy_r_r34 = 0 ? Py_True : Py_False;
     PyObject *cpy_r_r35[5] = {cpy_r_r28, cpy_r_r30, cpy_r_r31, cpy_r_r33, cpy_r_r34};
     cpy_r_r36 = (PyObject **)&cpy_r_r35;
-    cpy_r_r37 = CPyStatics[511]; /* ('default', 'verbose') */
+    cpy_r_r37 = CPyStatics[512]; /* ('default', 'verbose') */
     cpy_r_r38 = PyObject_VectorcallMethod(cpy_r_r32, cpy_r_r36, 9223372036854775811ULL, cpy_r_r37);
     if (unlikely(cpy_r_r38 == NULL)) {
         CPy_AddTraceback("y/ENVIRONMENT_VARIABLES.py", "<module>", 9, CPyStatic_ENVIRONMENT_VARIABLES___globals);
@@ -6139,7 +6248,7 @@ CPyL12: ;
     CPyStatic_ENVIRONMENT_VARIABLES___CACHE_TTL = cpy_r_r38;
     CPy_INCREF(CPyStatic_ENVIRONMENT_VARIABLES___CACHE_TTL);
     cpy_r_r39 = CPyStatic_ENVIRONMENT_VARIABLES___globals;
-    cpy_r_r40 = CPyStatics[123]; /* 'CACHE_TTL' */
+    cpy_r_r40 = CPyStatics[125]; /* 'CACHE_TTL' */
     cpy_r_r41 = CPyDict_SetItem(cpy_r_r39, cpy_r_r40, cpy_r_r38);
     CPy_DECREF(cpy_r_r38);
     cpy_r_r42 = cpy_r_r41 >= 0;
@@ -6157,7 +6266,7 @@ CPyL12: ;
     }
     CPy_Unreachable();
 CPyL17: ;
-    cpy_r_r45 = CPyStatics[125]; /* 'CONTRACT_CACHE_TTL' */
+    cpy_r_r45 = CPyStatics[127]; /* 'CONTRACT_CACHE_TTL' */
     cpy_r_r46 = (PyObject *)&PyLong_Type;
     cpy_r_r47 = CPyStatic_ENVIRONMENT_VARIABLES___CACHE_TTL;
     if (likely(cpy_r_r47 != NULL)) goto CPyL20;
@@ -6177,11 +6286,11 @@ CPyL20: ;
         CPy_AddTraceback("y/ENVIRONMENT_VARIABLES.py", "<module>", 13, CPyStatic_ENVIRONMENT_VARIABLES___globals);
         goto CPyL87;
     }
-    cpy_r_r53 = CPyStatics[119]; /* 'create_env' */
+    cpy_r_r53 = CPyStatics[121]; /* 'create_env' */
     cpy_r_r54 = 0 ? Py_True : Py_False;
     PyObject *cpy_r_r55[5] = {cpy_r_r43, cpy_r_r45, cpy_r_r46, cpy_r_r52, cpy_r_r54};
     cpy_r_r56 = (PyObject **)&cpy_r_r55;
-    cpy_r_r57 = CPyStatics[511]; /* ('default', 'verbose') */
+    cpy_r_r57 = CPyStatics[512]; /* ('default', 'verbose') */
     cpy_r_r58 = PyObject_VectorcallMethod(cpy_r_r53, cpy_r_r56, 9223372036854775811ULL, cpy_r_r57);
     if (unlikely(cpy_r_r58 == NULL)) {
         CPy_AddTraceback("y/ENVIRONMENT_VARIABLES.py", "<module>", 12, CPyStatic_ENVIRONMENT_VARIABLES___globals);
@@ -6191,7 +6300,7 @@ CPyL20: ;
     CPyStatic_ENVIRONMENT_VARIABLES___CONTRACT_CACHE_TTL = cpy_r_r58;
     CPy_INCREF(CPyStatic_ENVIRONMENT_VARIABLES___CONTRACT_CACHE_TTL);
     cpy_r_r59 = CPyStatic_ENVIRONMENT_VARIABLES___globals;
-    cpy_r_r60 = CPyStatics[125]; /* 'CONTRACT_CACHE_TTL' */
+    cpy_r_r60 = CPyStatics[127]; /* 'CONTRACT_CACHE_TTL' */
     cpy_r_r61 = CPyDict_SetItem(cpy_r_r59, cpy_r_r60, cpy_r_r58);
     CPy_DECREF(cpy_r_r58);
     cpy_r_r62 = cpy_r_r61 >= 0;
@@ -6209,13 +6318,13 @@ CPyL20: ;
     }
     CPy_Unreachable();
 CPyL26: ;
-    cpy_r_r65 = CPyStatics[126]; /* 'GETLOGS_BATCH_SIZE' */
+    cpy_r_r65 = CPyStatics[128]; /* 'GETLOGS_BATCH_SIZE' */
     cpy_r_r66 = (PyObject *)&PyLong_Type;
-    cpy_r_r67 = CPyStatics[119]; /* 'create_env' */
-    cpy_r_r68 = CPyStatics[469]; /* 0 */
+    cpy_r_r67 = CPyStatics[121]; /* 'create_env' */
+    cpy_r_r68 = CPyStatics[470]; /* 0 */
     PyObject *cpy_r_r69[4] = {cpy_r_r63, cpy_r_r65, cpy_r_r66, cpy_r_r68};
     cpy_r_r70 = (PyObject **)&cpy_r_r69;
-    cpy_r_r71 = CPyStatics[512]; /* ('default',) */
+    cpy_r_r71 = CPyStatics[513]; /* ('default',) */
     cpy_r_r72 = PyObject_VectorcallMethod(cpy_r_r67, cpy_r_r70, 9223372036854775811ULL, cpy_r_r71);
     if (unlikely(cpy_r_r72 == NULL)) {
         CPy_AddTraceback("y/ENVIRONMENT_VARIABLES.py", "<module>", 17, CPyStatic_ENVIRONMENT_VARIABLES___globals);
@@ -6224,7 +6333,7 @@ CPyL26: ;
     CPyStatic_ENVIRONMENT_VARIABLES___GETLOGS_BATCH_SIZE = cpy_r_r72;
     CPy_INCREF(CPyStatic_ENVIRONMENT_VARIABLES___GETLOGS_BATCH_SIZE);
     cpy_r_r73 = CPyStatic_ENVIRONMENT_VARIABLES___globals;
-    cpy_r_r74 = CPyStatics[126]; /* 'GETLOGS_BATCH_SIZE' */
+    cpy_r_r74 = CPyStatics[128]; /* 'GETLOGS_BATCH_SIZE' */
     cpy_r_r75 = CPyDict_SetItem(cpy_r_r73, cpy_r_r74, cpy_r_r72);
     CPy_DECREF(cpy_r_r72);
     cpy_r_r76 = cpy_r_r75 >= 0;
@@ -6242,14 +6351,14 @@ CPyL26: ;
     }
     CPy_Unreachable();
 CPyL31: ;
-    cpy_r_r79 = CPyStatics[127]; /* 'GETLOGS_DOP' */
+    cpy_r_r79 = CPyStatics[129]; /* 'GETLOGS_DOP' */
     cpy_r_r80 = (PyObject *)&PyLong_Type;
-    cpy_r_r81 = CPyStatics[119]; /* 'create_env' */
-    cpy_r_r82 = CPyStatics[470]; /* 32 */
+    cpy_r_r81 = CPyStatics[121]; /* 'create_env' */
+    cpy_r_r82 = CPyStatics[471]; /* 32 */
     cpy_r_r83 = 0 ? Py_True : Py_False;
     PyObject *cpy_r_r84[5] = {cpy_r_r77, cpy_r_r79, cpy_r_r80, cpy_r_r82, cpy_r_r83};
     cpy_r_r85 = (PyObject **)&cpy_r_r84;
-    cpy_r_r86 = CPyStatics[511]; /* ('default', 'verbose') */
+    cpy_r_r86 = CPyStatics[512]; /* ('default', 'verbose') */
     cpy_r_r87 = PyObject_VectorcallMethod(cpy_r_r81, cpy_r_r85, 9223372036854775811ULL, cpy_r_r86);
     if (unlikely(cpy_r_r87 == NULL)) {
         CPy_AddTraceback("y/ENVIRONMENT_VARIABLES.py", "<module>", 20, CPyStatic_ENVIRONMENT_VARIABLES___globals);
@@ -6258,7 +6367,7 @@ CPyL31: ;
     CPyStatic_ENVIRONMENT_VARIABLES___GETLOGS_DOP = cpy_r_r87;
     CPy_INCREF(CPyStatic_ENVIRONMENT_VARIABLES___GETLOGS_DOP);
     cpy_r_r88 = CPyStatic_ENVIRONMENT_VARIABLES___globals;
-    cpy_r_r89 = CPyStatics[127]; /* 'GETLOGS_DOP' */
+    cpy_r_r89 = CPyStatics[129]; /* 'GETLOGS_DOP' */
     cpy_r_r90 = CPyDict_SetItem(cpy_r_r88, cpy_r_r89, cpy_r_r87);
     CPy_DECREF(cpy_r_r87);
     cpy_r_r91 = cpy_r_r90 >= 0;
@@ -6276,14 +6385,14 @@ CPyL31: ;
     }
     CPy_Unreachable();
 CPyL36: ;
-    cpy_r_r94 = CPyStatics[128]; /* 'CHECKSUM_CACHE_MAXSIZE' */
+    cpy_r_r94 = CPyStatics[130]; /* 'CHECKSUM_CACHE_MAXSIZE' */
     cpy_r_r95 = (PyObject *)&PyLong_Type;
-    cpy_r_r96 = CPyStatics[119]; /* 'create_env' */
-    cpy_r_r97 = CPyStatics[471]; /* 100000 */
+    cpy_r_r96 = CPyStatics[121]; /* 'create_env' */
+    cpy_r_r97 = CPyStatics[472]; /* 100000 */
     cpy_r_r98 = 0 ? Py_True : Py_False;
     PyObject *cpy_r_r99[5] = {cpy_r_r92, cpy_r_r94, cpy_r_r95, cpy_r_r97, cpy_r_r98};
     cpy_r_r100 = (PyObject **)&cpy_r_r99;
-    cpy_r_r101 = CPyStatics[511]; /* ('default', 'verbose') */
+    cpy_r_r101 = CPyStatics[512]; /* ('default', 'verbose') */
     cpy_r_r102 = PyObject_VectorcallMethod(cpy_r_r96, cpy_r_r100, 9223372036854775811ULL, cpy_r_r101);
     if (unlikely(cpy_r_r102 == NULL)) {
         CPy_AddTraceback("y/ENVIRONMENT_VARIABLES.py", "<module>", 23, CPyStatic_ENVIRONMENT_VARIABLES___globals);
@@ -6292,7 +6401,7 @@ CPyL36: ;
     CPyStatic_ENVIRONMENT_VARIABLES___CHECKSUM_CACHE_MAXSIZE = cpy_r_r102;
     CPy_INCREF(CPyStatic_ENVIRONMENT_VARIABLES___CHECKSUM_CACHE_MAXSIZE);
     cpy_r_r103 = CPyStatic_ENVIRONMENT_VARIABLES___globals;
-    cpy_r_r104 = CPyStatics[128]; /* 'CHECKSUM_CACHE_MAXSIZE' */
+    cpy_r_r104 = CPyStatics[130]; /* 'CHECKSUM_CACHE_MAXSIZE' */
     cpy_r_r105 = CPyDict_SetItem(cpy_r_r103, cpy_r_r104, cpy_r_r102);
     CPy_DECREF(cpy_r_r102);
     cpy_r_r106 = cpy_r_r105 >= 0;
@@ -6310,14 +6419,14 @@ CPyL36: ;
     }
     CPy_Unreachable();
 CPyL41: ;
-    cpy_r_r109 = CPyStatics[129]; /* 'DB_PROVIDER' */
+    cpy_r_r109 = CPyStatics[131]; /* 'DB_PROVIDER' */
     cpy_r_r110 = (PyObject *)&PyUnicode_Type;
-    cpy_r_r111 = CPyStatics[71]; /* 'sqlite' */
-    cpy_r_r112 = CPyStatics[119]; /* 'create_env' */
+    cpy_r_r111 = CPyStatics[76]; /* 'sqlite' */
+    cpy_r_r112 = CPyStatics[121]; /* 'create_env' */
     cpy_r_r113 = 0 ? Py_True : Py_False;
     PyObject *cpy_r_r114[5] = {cpy_r_r107, cpy_r_r109, cpy_r_r110, cpy_r_r111, cpy_r_r113};
     cpy_r_r115 = (PyObject **)&cpy_r_r114;
-    cpy_r_r116 = CPyStatics[511]; /* ('default', 'verbose') */
+    cpy_r_r116 = CPyStatics[512]; /* ('default', 'verbose') */
     cpy_r_r117 = PyObject_VectorcallMethod(cpy_r_r112, cpy_r_r115, 9223372036854775811ULL, cpy_r_r116);
     if (unlikely(cpy_r_r117 == NULL)) {
         CPy_AddTraceback("y/ENVIRONMENT_VARIABLES.py", "<module>", 28, CPyStatic_ENVIRONMENT_VARIABLES___globals);
@@ -6326,7 +6435,7 @@ CPyL41: ;
     CPyStatic_ENVIRONMENT_VARIABLES___DB_PROVIDER = cpy_r_r117;
     CPy_INCREF(CPyStatic_ENVIRONMENT_VARIABLES___DB_PROVIDER);
     cpy_r_r118 = CPyStatic_ENVIRONMENT_VARIABLES___globals;
-    cpy_r_r119 = CPyStatics[129]; /* 'DB_PROVIDER' */
+    cpy_r_r119 = CPyStatics[131]; /* 'DB_PROVIDER' */
     cpy_r_r120 = CPyDict_SetItem(cpy_r_r118, cpy_r_r119, cpy_r_r117);
     CPy_DECREF(cpy_r_r117);
     cpy_r_r121 = cpy_r_r120 >= 0;
@@ -6344,17 +6453,17 @@ CPyL41: ;
     }
     CPy_Unreachable();
 CPyL46: ;
-    cpy_r_r124 = CPyStatics[130]; /* 'SQLITE_PATH' */
+    cpy_r_r124 = CPyStatics[132]; /* 'SQLITE_PATH' */
     cpy_r_r125 = (PyObject *)&PyUnicode_Type;
-    cpy_r_r126 = CPyStatics[100]; /* '~' */
+    cpy_r_r126 = CPyStatics[102]; /* '~' */
     cpy_r_r127 = CPyStatic_ENVIRONMENT_VARIABLES___globals;
-    cpy_r_r128 = CPyStatics[95]; /* 'path' */
+    cpy_r_r128 = CPyStatics[100]; /* 'path' */
     cpy_r_r129 = CPyDict_GetItem(cpy_r_r127, cpy_r_r128);
     if (unlikely(cpy_r_r129 == NULL)) {
         CPy_AddTraceback("y/ENVIRONMENT_VARIABLES.py", "<module>", 34, CPyStatic_ENVIRONMENT_VARIABLES___globals);
         goto CPyL87;
     }
-    cpy_r_r130 = CPyStatics[101]; /* 'expanduser' */
+    cpy_r_r130 = CPyStatics[103]; /* 'expanduser' */
     cpy_r_r131 = CPyObject_GetAttr(cpy_r_r129, cpy_r_r130);
     CPy_DECREF(cpy_r_r129);
     if (unlikely(cpy_r_r131 == NULL)) {
@@ -6375,18 +6484,18 @@ CPyL46: ;
         CPy_TypeErrorTraceback("y/ENVIRONMENT_VARIABLES.py", "<module>", 34, CPyStatic_ENVIRONMENT_VARIABLES___globals, "str", cpy_r_r134);
         goto CPyL87;
     }
-    cpy_r_r136 = CPyStatics[131]; /* '/.ypricemagic/ypricemagic.sqlite' */
+    cpy_r_r136 = CPyStatics[133]; /* '/.ypricemagic/ypricemagic.sqlite' */
     cpy_r_r137 = CPyStr_Build(2, cpy_r_r135, cpy_r_r136);
     CPy_DECREF(cpy_r_r135);
     if (unlikely(cpy_r_r137 == NULL)) {
         CPy_AddTraceback("y/ENVIRONMENT_VARIABLES.py", "<module>", 34, CPyStatic_ENVIRONMENT_VARIABLES___globals);
         goto CPyL87;
     }
-    cpy_r_r138 = CPyStatics[119]; /* 'create_env' */
+    cpy_r_r138 = CPyStatics[121]; /* 'create_env' */
     cpy_r_r139 = 0 ? Py_True : Py_False;
     PyObject *cpy_r_r140[5] = {cpy_r_r122, cpy_r_r124, cpy_r_r125, cpy_r_r137, cpy_r_r139};
     cpy_r_r141 = (PyObject **)&cpy_r_r140;
-    cpy_r_r142 = CPyStatics[511]; /* ('default', 'verbose') */
+    cpy_r_r142 = CPyStatics[512]; /* ('default', 'verbose') */
     cpy_r_r143 = PyObject_VectorcallMethod(cpy_r_r138, cpy_r_r141, 9223372036854775811ULL, cpy_r_r142);
     if (unlikely(cpy_r_r143 == NULL)) {
         CPy_AddTraceback("y/ENVIRONMENT_VARIABLES.py", "<module>", 31, CPyStatic_ENVIRONMENT_VARIABLES___globals);
@@ -6396,7 +6505,7 @@ CPyL46: ;
     CPyStatic_ENVIRONMENT_VARIABLES___SQLITE_PATH = cpy_r_r143;
     CPy_INCREF(CPyStatic_ENVIRONMENT_VARIABLES___SQLITE_PATH);
     cpy_r_r144 = CPyStatic_ENVIRONMENT_VARIABLES___globals;
-    cpy_r_r145 = CPyStatics[130]; /* 'SQLITE_PATH' */
+    cpy_r_r145 = CPyStatics[132]; /* 'SQLITE_PATH' */
     cpy_r_r146 = CPyDict_SetItem(cpy_r_r144, cpy_r_r145, cpy_r_r143);
     CPy_DECREF(cpy_r_r143);
     cpy_r_r147 = cpy_r_r146 >= 0;
@@ -6414,14 +6523,14 @@ CPyL46: ;
     }
     CPy_Unreachable();
 CPyL56: ;
-    cpy_r_r150 = CPyStatics[132]; /* 'DB_HOST' */
+    cpy_r_r150 = CPyStatics[134]; /* 'DB_HOST' */
     cpy_r_r151 = (PyObject *)&PyUnicode_Type;
-    cpy_r_r152 = CPyStatics[133]; /* '' */
-    cpy_r_r153 = CPyStatics[119]; /* 'create_env' */
+    cpy_r_r152 = CPyStatics[135]; /* '' */
+    cpy_r_r153 = CPyStatics[121]; /* 'create_env' */
     cpy_r_r154 = 0 ? Py_True : Py_False;
     PyObject *cpy_r_r155[5] = {cpy_r_r148, cpy_r_r150, cpy_r_r151, cpy_r_r152, cpy_r_r154};
     cpy_r_r156 = (PyObject **)&cpy_r_r155;
-    cpy_r_r157 = CPyStatics[511]; /* ('default', 'verbose') */
+    cpy_r_r157 = CPyStatics[512]; /* ('default', 'verbose') */
     cpy_r_r158 = PyObject_VectorcallMethod(cpy_r_r153, cpy_r_r156, 9223372036854775811ULL, cpy_r_r157);
     if (unlikely(cpy_r_r158 == NULL)) {
         CPy_AddTraceback("y/ENVIRONMENT_VARIABLES.py", "<module>", 45, CPyStatic_ENVIRONMENT_VARIABLES___globals);
@@ -6430,7 +6539,7 @@ CPyL56: ;
     CPyStatic_ENVIRONMENT_VARIABLES___DB_HOST = cpy_r_r158;
     CPy_INCREF(CPyStatic_ENVIRONMENT_VARIABLES___DB_HOST);
     cpy_r_r159 = CPyStatic_ENVIRONMENT_VARIABLES___globals;
-    cpy_r_r160 = CPyStatics[132]; /* 'DB_HOST' */
+    cpy_r_r160 = CPyStatics[134]; /* 'DB_HOST' */
     cpy_r_r161 = CPyDict_SetItem(cpy_r_r159, cpy_r_r160, cpy_r_r158);
     CPy_DECREF(cpy_r_r158);
     cpy_r_r162 = cpy_r_r161 >= 0;
@@ -6448,14 +6557,14 @@ CPyL56: ;
     }
     CPy_Unreachable();
 CPyL61: ;
-    cpy_r_r165 = CPyStatics[134]; /* 'DB_PORT' */
+    cpy_r_r165 = CPyStatics[136]; /* 'DB_PORT' */
     cpy_r_r166 = (PyObject *)&PyUnicode_Type;
-    cpy_r_r167 = CPyStatics[133]; /* '' */
-    cpy_r_r168 = CPyStatics[119]; /* 'create_env' */
+    cpy_r_r167 = CPyStatics[135]; /* '' */
+    cpy_r_r168 = CPyStatics[121]; /* 'create_env' */
     cpy_r_r169 = 0 ? Py_True : Py_False;
     PyObject *cpy_r_r170[5] = {cpy_r_r163, cpy_r_r165, cpy_r_r166, cpy_r_r167, cpy_r_r169};
     cpy_r_r171 = (PyObject **)&cpy_r_r170;
-    cpy_r_r172 = CPyStatics[511]; /* ('default', 'verbose') */
+    cpy_r_r172 = CPyStatics[512]; /* ('default', 'verbose') */
     cpy_r_r173 = PyObject_VectorcallMethod(cpy_r_r168, cpy_r_r171, 9223372036854775811ULL, cpy_r_r172);
     if (unlikely(cpy_r_r173 == NULL)) {
         CPy_AddTraceback("y/ENVIRONMENT_VARIABLES.py", "<module>", 48, CPyStatic_ENVIRONMENT_VARIABLES___globals);
@@ -6464,7 +6573,7 @@ CPyL61: ;
     CPyStatic_ENVIRONMENT_VARIABLES___DB_PORT = cpy_r_r173;
     CPy_INCREF(CPyStatic_ENVIRONMENT_VARIABLES___DB_PORT);
     cpy_r_r174 = CPyStatic_ENVIRONMENT_VARIABLES___globals;
-    cpy_r_r175 = CPyStatics[134]; /* 'DB_PORT' */
+    cpy_r_r175 = CPyStatics[136]; /* 'DB_PORT' */
     cpy_r_r176 = CPyDict_SetItem(cpy_r_r174, cpy_r_r175, cpy_r_r173);
     CPy_DECREF(cpy_r_r173);
     cpy_r_r177 = cpy_r_r176 >= 0;
@@ -6482,14 +6591,14 @@ CPyL61: ;
     }
     CPy_Unreachable();
 CPyL66: ;
-    cpy_r_r180 = CPyStatics[135]; /* 'DB_USER' */
+    cpy_r_r180 = CPyStatics[137]; /* 'DB_USER' */
     cpy_r_r181 = (PyObject *)&PyUnicode_Type;
-    cpy_r_r182 = CPyStatics[133]; /* '' */
-    cpy_r_r183 = CPyStatics[119]; /* 'create_env' */
+    cpy_r_r182 = CPyStatics[135]; /* '' */
+    cpy_r_r183 = CPyStatics[121]; /* 'create_env' */
     cpy_r_r184 = 0 ? Py_True : Py_False;
     PyObject *cpy_r_r185[5] = {cpy_r_r178, cpy_r_r180, cpy_r_r181, cpy_r_r182, cpy_r_r184};
     cpy_r_r186 = (PyObject **)&cpy_r_r185;
-    cpy_r_r187 = CPyStatics[511]; /* ('default', 'verbose') */
+    cpy_r_r187 = CPyStatics[512]; /* ('default', 'verbose') */
     cpy_r_r188 = PyObject_VectorcallMethod(cpy_r_r183, cpy_r_r186, 9223372036854775811ULL, cpy_r_r187);
     if (unlikely(cpy_r_r188 == NULL)) {
         CPy_AddTraceback("y/ENVIRONMENT_VARIABLES.py", "<module>", 51, CPyStatic_ENVIRONMENT_VARIABLES___globals);
@@ -6498,7 +6607,7 @@ CPyL66: ;
     CPyStatic_ENVIRONMENT_VARIABLES___DB_USER = cpy_r_r188;
     CPy_INCREF(CPyStatic_ENVIRONMENT_VARIABLES___DB_USER);
     cpy_r_r189 = CPyStatic_ENVIRONMENT_VARIABLES___globals;
-    cpy_r_r190 = CPyStatics[135]; /* 'DB_USER' */
+    cpy_r_r190 = CPyStatics[137]; /* 'DB_USER' */
     cpy_r_r191 = CPyDict_SetItem(cpy_r_r189, cpy_r_r190, cpy_r_r188);
     CPy_DECREF(cpy_r_r188);
     cpy_r_r192 = cpy_r_r191 >= 0;
@@ -6516,14 +6625,14 @@ CPyL66: ;
     }
     CPy_Unreachable();
 CPyL71: ;
-    cpy_r_r195 = CPyStatics[136]; /* 'DB_PASSWORD' */
+    cpy_r_r195 = CPyStatics[138]; /* 'DB_PASSWORD' */
     cpy_r_r196 = (PyObject *)&PyUnicode_Type;
-    cpy_r_r197 = CPyStatics[133]; /* '' */
-    cpy_r_r198 = CPyStatics[119]; /* 'create_env' */
+    cpy_r_r197 = CPyStatics[135]; /* '' */
+    cpy_r_r198 = CPyStatics[121]; /* 'create_env' */
     cpy_r_r199 = 0 ? Py_True : Py_False;
     PyObject *cpy_r_r200[5] = {cpy_r_r193, cpy_r_r195, cpy_r_r196, cpy_r_r197, cpy_r_r199};
     cpy_r_r201 = (PyObject **)&cpy_r_r200;
-    cpy_r_r202 = CPyStatics[511]; /* ('default', 'verbose') */
+    cpy_r_r202 = CPyStatics[512]; /* ('default', 'verbose') */
     cpy_r_r203 = PyObject_VectorcallMethod(cpy_r_r198, cpy_r_r201, 9223372036854775811ULL, cpy_r_r202);
     if (unlikely(cpy_r_r203 == NULL)) {
         CPy_AddTraceback("y/ENVIRONMENT_VARIABLES.py", "<module>", 54, CPyStatic_ENVIRONMENT_VARIABLES___globals);
@@ -6532,7 +6641,7 @@ CPyL71: ;
     CPyStatic_ENVIRONMENT_VARIABLES___DB_PASSWORD = cpy_r_r203;
     CPy_INCREF(CPyStatic_ENVIRONMENT_VARIABLES___DB_PASSWORD);
     cpy_r_r204 = CPyStatic_ENVIRONMENT_VARIABLES___globals;
-    cpy_r_r205 = CPyStatics[136]; /* 'DB_PASSWORD' */
+    cpy_r_r205 = CPyStatics[138]; /* 'DB_PASSWORD' */
     cpy_r_r206 = CPyDict_SetItem(cpy_r_r204, cpy_r_r205, cpy_r_r203);
     CPy_DECREF(cpy_r_r203);
     cpy_r_r207 = cpy_r_r206 >= 0;
@@ -6550,14 +6659,14 @@ CPyL71: ;
     }
     CPy_Unreachable();
 CPyL76: ;
-    cpy_r_r210 = CPyStatics[137]; /* 'DB_DATABASE' */
+    cpy_r_r210 = CPyStatics[139]; /* 'DB_DATABASE' */
     cpy_r_r211 = (PyObject *)&PyUnicode_Type;
-    cpy_r_r212 = CPyStatics[138]; /* 'ypricemagic' */
-    cpy_r_r213 = CPyStatics[119]; /* 'create_env' */
+    cpy_r_r212 = CPyStatics[140]; /* 'ypricemagic' */
+    cpy_r_r213 = CPyStatics[121]; /* 'create_env' */
     cpy_r_r214 = 0 ? Py_True : Py_False;
     PyObject *cpy_r_r215[5] = {cpy_r_r208, cpy_r_r210, cpy_r_r211, cpy_r_r212, cpy_r_r214};
     cpy_r_r216 = (PyObject **)&cpy_r_r215;
-    cpy_r_r217 = CPyStatics[511]; /* ('default', 'verbose') */
+    cpy_r_r217 = CPyStatics[512]; /* ('default', 'verbose') */
     cpy_r_r218 = PyObject_VectorcallMethod(cpy_r_r213, cpy_r_r216, 9223372036854775811ULL, cpy_r_r217);
     if (unlikely(cpy_r_r218 == NULL)) {
         CPy_AddTraceback("y/ENVIRONMENT_VARIABLES.py", "<module>", 57, CPyStatic_ENVIRONMENT_VARIABLES___globals);
@@ -6566,7 +6675,7 @@ CPyL76: ;
     CPyStatic_ENVIRONMENT_VARIABLES___DB_DATABASE = cpy_r_r218;
     CPy_INCREF(CPyStatic_ENVIRONMENT_VARIABLES___DB_DATABASE);
     cpy_r_r219 = CPyStatic_ENVIRONMENT_VARIABLES___globals;
-    cpy_r_r220 = CPyStatics[137]; /* 'DB_DATABASE' */
+    cpy_r_r220 = CPyStatics[139]; /* 'DB_DATABASE' */
     cpy_r_r221 = CPyDict_SetItem(cpy_r_r219, cpy_r_r220, cpy_r_r218);
     CPy_DECREF(cpy_r_r218);
     cpy_r_r222 = cpy_r_r221 >= 0;
@@ -6584,14 +6693,14 @@ CPyL76: ;
     }
     CPy_Unreachable();
 CPyL81: ;
-    cpy_r_r225 = CPyStatics[139]; /* 'SKIP_CACHE' */
+    cpy_r_r225 = CPyStatics[141]; /* 'SKIP_CACHE' */
     cpy_r_r226 = (PyObject *)&PyBool_Type;
-    cpy_r_r227 = CPyStatics[119]; /* 'create_env' */
+    cpy_r_r227 = CPyStatics[121]; /* 'create_env' */
     cpy_r_r228 = 0 ? Py_True : Py_False;
     cpy_r_r229 = 0 ? Py_True : Py_False;
     PyObject *cpy_r_r230[5] = {cpy_r_r223, cpy_r_r225, cpy_r_r226, cpy_r_r228, cpy_r_r229};
     cpy_r_r231 = (PyObject **)&cpy_r_r230;
-    cpy_r_r232 = CPyStatics[511]; /* ('default', 'verbose') */
+    cpy_r_r232 = CPyStatics[512]; /* ('default', 'verbose') */
     cpy_r_r233 = PyObject_VectorcallMethod(cpy_r_r227, cpy_r_r231, 9223372036854775811ULL, cpy_r_r232);
     if (unlikely(cpy_r_r233 == NULL)) {
         CPy_AddTraceback("y/ENVIRONMENT_VARIABLES.py", "<module>", 60, CPyStatic_ENVIRONMENT_VARIABLES___globals);
@@ -6600,7 +6709,7 @@ CPyL81: ;
     CPyStatic_ENVIRONMENT_VARIABLES___SKIP_CACHE = cpy_r_r233;
     CPy_INCREF(CPyStatic_ENVIRONMENT_VARIABLES___SKIP_CACHE);
     cpy_r_r234 = CPyStatic_ENVIRONMENT_VARIABLES___globals;
-    cpy_r_r235 = CPyStatics[139]; /* 'SKIP_CACHE' */
+    cpy_r_r235 = CPyStatics[141]; /* 'SKIP_CACHE' */
     cpy_r_r236 = CPyDict_SetItem(cpy_r_r234, cpy_r_r235, cpy_r_r233);
     CPy_DECREF(cpy_r_r233);
     cpy_r_r237 = cpy_r_r236 >= 0;
@@ -6608,10 +6717,10 @@ CPyL81: ;
         CPy_AddTraceback("y/ENVIRONMENT_VARIABLES.py", "<module>", 60, CPyStatic_ENVIRONMENT_VARIABLES___globals);
         goto CPyL87;
     }
-    cpy_r_r238 = CPyStatics[140]; /* 'SKIP_YPRICEAPI' */
+    cpy_r_r238 = CPyStatics[142]; /* 'SKIP_YPRICEAPI' */
     cpy_r_r239 = (PyObject *)&PyBool_Type;
     cpy_r_r240 = CPyStatic_ENVIRONMENT_VARIABLES___globals;
-    cpy_r_r241 = CPyStatics[119]; /* 'create_env' */
+    cpy_r_r241 = CPyStatics[121]; /* 'create_env' */
     cpy_r_r242 = CPyDict_GetItem(cpy_r_r240, cpy_r_r241);
     if (unlikely(cpy_r_r242 == NULL)) {
         CPy_AddTraceback("y/ENVIRONMENT_VARIABLES.py", "<module>", 64, CPyStatic_ENVIRONMENT_VARIABLES___globals);
@@ -6621,7 +6730,7 @@ CPyL81: ;
     cpy_r_r244 = 0 ? Py_True : Py_False;
     PyObject *cpy_r_r245[4] = {cpy_r_r238, cpy_r_r239, cpy_r_r243, cpy_r_r244};
     cpy_r_r246 = (PyObject **)&cpy_r_r245;
-    cpy_r_r247 = CPyStatics[511]; /* ('default', 'verbose') */
+    cpy_r_r247 = CPyStatics[512]; /* ('default', 'verbose') */
     cpy_r_r248 = PyObject_Vectorcall(cpy_r_r242, cpy_r_r246, 2, cpy_r_r247);
     CPy_DECREF(cpy_r_r242);
     if (unlikely(cpy_r_r248 == NULL)) {
@@ -6631,7 +6740,7 @@ CPyL81: ;
     CPyStatic_ENVIRONMENT_VARIABLES___SKIP_YPRICEAPI = cpy_r_r248;
     CPy_INCREF(CPyStatic_ENVIRONMENT_VARIABLES___SKIP_YPRICEAPI);
     cpy_r_r249 = CPyStatic_ENVIRONMENT_VARIABLES___globals;
-    cpy_r_r250 = CPyStatics[140]; /* 'SKIP_YPRICEAPI' */
+    cpy_r_r250 = CPyStatics[142]; /* 'SKIP_YPRICEAPI' */
     cpy_r_r251 = CPyDict_SetItem(cpy_r_r249, cpy_r_r250, cpy_r_r248);
     CPy_DECREF(cpy_r_r248);
     cpy_r_r252 = cpy_r_r251 >= 0;
@@ -6995,7 +7104,7 @@ CPyL4: ;
 CPyL6: ;
     cpy_r_r5 = CPy_CatchError();
     cpy_r_r6 = CPyModule_builtins;
-    cpy_r_r7 = CPyStatics[141]; /* 'ValueError' */
+    cpy_r_r7 = CPyStatics[143]; /* 'ValueError' */
     cpy_r_r8 = CPyObject_GetAttr(cpy_r_r6, cpy_r_r7);
     if (unlikely(cpy_r_r8 == NULL)) {
         CPy_AddTraceback("y/convert.py", "checksum", 43, CPyStatic_convert___globals);
@@ -7009,7 +7118,7 @@ CPyL6: ;
         CPy_AddTraceback("y/convert.py", "checksum", 44, CPyStatic_convert___globals);
         goto CPyL16;
     }
-    cpy_r_r11 = CPyStatics[142]; /* ' is not a valid ETH address' */
+    cpy_r_r11 = CPyStatics[144]; /* ' is not a valid ETH address' */
     cpy_r_r12 = CPyStr_Build(2, cpy_r_r10, cpy_r_r11);
     CPy_DecRef(cpy_r_r10);
     if (unlikely(cpy_r_r12 == NULL)) {
@@ -7017,7 +7126,7 @@ CPyL6: ;
         goto CPyL16;
     }
     cpy_r_r13 = CPyModule_builtins;
-    cpy_r_r14 = CPyStatics[141]; /* 'ValueError' */
+    cpy_r_r14 = CPyStatics[143]; /* 'ValueError' */
     cpy_r_r15 = CPyObject_GetAttr(cpy_r_r13, cpy_r_r14);
     if (unlikely(cpy_r_r15 == NULL)) {
         CPy_AddTraceback("y/convert.py", "checksum", 44, CPyStatic_convert___globals);
@@ -7140,7 +7249,7 @@ CPyL6: ;
     return cpy_r_checksummed;
 CPyL7: ;
     cpy_r_r8 = CPyStatic_convert___globals;
-    cpy_r_r9 = CPyStatics[143]; /* 'checksum' */
+    cpy_r_r9 = CPyStatics[145]; /* 'checksum' */
     cpy_r_r10 = CPyDict_GetItem(cpy_r_r8, cpy_r_r9);
     if (unlikely(cpy_r_r10 == NULL)) {
         CPy_AddTraceback("y/convert.py", "to_address", 70, CPyStatic_convert___globals);
@@ -7411,7 +7520,7 @@ CPyL20: ;
     CPy_Unreachable();
 CPyL22: ;
     cpy_r_r22 = CPyStatic_convert___globals;
-    cpy_r_r23 = CPyStatics[143]; /* 'checksum' */
+    cpy_r_r23 = CPyStatics[145]; /* 'checksum' */
     cpy_r_r24 = CPyDict_GetItem(cpy_r_r22, cpy_r_r23);
     if (unlikely(cpy_r_r24 == NULL)) {
         CPy_AddTraceback("y/convert.py", "to_address_async", 102, CPyStatic_convert___globals);
@@ -7424,7 +7533,7 @@ CPyL22: ;
     }
     CPy_INCREF(cpy_r_r25);
 CPyL24: ;
-    cpy_r_r26 = CPyStatics[144]; /* 'run' */
+    cpy_r_r26 = CPyStatics[146]; /* 'run' */
     PyObject *cpy_r_r27[3] = {cpy_r_r20, cpy_r_r24, cpy_r_r25};
     cpy_r_r28 = (PyObject **)&cpy_r_r27;
     cpy_r_r29 = PyObject_VectorcallMethod(cpy_r_r26, cpy_r_r28, 9223372036854775811ULL, 0);
@@ -7969,7 +8078,7 @@ PyObject *CPyDef_convert___to_address_async_gen___close(PyObject *cpy_r___mypyc_
     char cpy_r_r14;
     PyObject *cpy_r_r15;
     cpy_r_r0 = CPyModule_builtins;
-    cpy_r_r1 = CPyStatics[145]; /* 'GeneratorExit' */
+    cpy_r_r1 = CPyStatics[147]; /* 'GeneratorExit' */
     cpy_r_r2 = CPyObject_GetAttr(cpy_r_r0, cpy_r_r1);
     if (cpy_r_r2 == NULL) goto CPyL3;
     cpy_r_r3 = (PyObject *)&_Py_NoneStruct;
@@ -7979,7 +8088,7 @@ PyObject *CPyDef_convert___to_address_async_gen___close(PyObject *cpy_r___mypyc_
 CPyL3: ;
     cpy_r_r6 = CPy_CatchError();
     cpy_r_r7 = CPyModule_builtins;
-    cpy_r_r8 = CPyStatics[146]; /* 'StopIteration' */
+    cpy_r_r8 = CPyStatics[148]; /* 'StopIteration' */
     cpy_r_r9 = CPyObject_GetAttr(cpy_r_r7, cpy_r_r8);
     if (cpy_r_r9 == NULL) goto CPyL12;
     cpy_r_r10.f0 = cpy_r_r2;
@@ -8230,7 +8339,7 @@ CPyL9: ;
     cpy_r_r9 = cpy_r_r7;
     if (!cpy_r_r9) goto CPyL14;
     cpy_r_r10 = CPyStatic_convert___globals;
-    cpy_r_r11 = CPyStatics[143]; /* 'checksum' */
+    cpy_r_r11 = CPyStatics[145]; /* 'checksum' */
     cpy_r_r12 = CPyDict_GetItem(cpy_r_r10, cpy_r_r11);
     if (unlikely(cpy_r_r12 == NULL)) {
         CPy_AddTraceback("y/convert.py", "__get_checksum_from_cache", 132, CPyStatic_convert___globals);
@@ -8412,7 +8521,7 @@ CPyL1: ;
 CPyL2: ;
     cpy_r_r3 = (PyObject *)&PyBytes_Type;
     cpy_r_r4 = CPyModule_builtins;
-    cpy_r_r5 = CPyStatics[147]; /* 'issubclass' */
+    cpy_r_r5 = CPyStatics[149]; /* 'issubclass' */
     cpy_r_r6 = CPyObject_GetAttr(cpy_r_r4, cpy_r_r5);
     if (unlikely(cpy_r_r6 == NULL)) {
         CPy_AddTraceback("y/convert.py", "__normalize_input_to_string", 180, CPyStatic_convert___globals);
@@ -8449,7 +8558,7 @@ CPyL2: ;
         CPy_TypeErrorTraceback("y/convert.py", "__normalize_input_to_string", 183, CPyStatic_convert___globals, "str", cpy_r_r12);
         goto CPyL29;
     }
-    cpy_r_r14 = CPyStatics[148]; /* 'HexBytes' */
+    cpy_r_r14 = CPyStatics[150]; /* 'HexBytes' */
     cpy_r_r15 = PyUnicode_Compare(cpy_r_r13, cpy_r_r14);
     CPy_DECREF(cpy_r_r13);
     cpy_r_r16 = cpy_r_r15 == -1;
@@ -8467,7 +8576,7 @@ CPyL11: ;
     if (!cpy_r_r20) goto CPyL15;
     CPy_INCREF(cpy_r_address);
     cpy_r_r21 = cpy_r_address;
-    cpy_r_r22 = CPyStatics[73]; /* 'hex' */
+    cpy_r_r22 = CPyStatics[78]; /* 'hex' */
     PyObject *cpy_r_r23[1] = {cpy_r_r21};
     cpy_r_r24 = (PyObject **)&cpy_r_r23;
     cpy_r_r25 = PyObject_VectorcallMethod(cpy_r_r22, cpy_r_r24, 9223372036854775809ULL, 0);
@@ -8497,7 +8606,7 @@ CPyL18: ;
         CPy_AddTraceback("y/convert.py", "__normalize_input_to_string", 184, CPyStatic_convert___globals);
         goto CPyL29;
     }
-    cpy_r_r33 = CPyStatics[73]; /* 'hex' */
+    cpy_r_r33 = CPyStatics[78]; /* 'hex' */
     PyObject *cpy_r_r34[1] = {cpy_r_r32};
     cpy_r_r35 = (PyObject **)&cpy_r_r34;
     cpy_r_r36 = PyObject_VectorcallMethod(cpy_r_r33, cpy_r_r35, 9223372036854775809ULL, 0);
@@ -8635,7 +8744,7 @@ CPyL3: ;
         goto CPyL14;
     }
     CPy_DECREF(cpy_r_r2);
-    cpy_r_r6 = CPyStatics[73]; /* 'hex' */
+    cpy_r_r6 = CPyStatics[78]; /* 'hex' */
     PyObject *cpy_r_r7[1] = {cpy_r_r5};
     cpy_r_r8 = (PyObject **)&cpy_r_r7;
     cpy_r_r9 = PyObject_VectorcallMethod(cpy_r_r6, cpy_r_r8, 9223372036854775809ULL, 0);
@@ -8662,7 +8771,7 @@ CPyL3: ;
         CPy_TypeErrorTraceback("y/convert.py", "_int_to_address", 208, CPyStatic_convert___globals, "str", cpy_r_r11);
         goto CPyL13;
     }
-    cpy_r_r13 = CPyStatics[149]; /* '0' */
+    cpy_r_r13 = CPyStatics[151]; /* '0' */
     cpy_r_r14 = CPyStr_Size_size_t(cpy_r_r12);
     cpy_r_r15 = cpy_r_r14 >= 0;
     if (unlikely(!cpy_r_r15)) {
@@ -8684,7 +8793,7 @@ CPyL3: ;
         CPy_TypeErrorTraceback("y/convert.py", "_int_to_address", 209, CPyStatic_convert___globals, "str", cpy_r_r19);
         goto CPyL16;
     }
-    cpy_r_r21 = CPyStatics[150]; /* '0x' */
+    cpy_r_r21 = CPyStatics[152]; /* '0x' */
     cpy_r_r22 = CPyStr_Build(3, cpy_r_r21, cpy_r_r20, cpy_r_r12);
     CPy_DECREF(cpy_r_r20);
     CPy_DECREF(cpy_r_r12);
@@ -8830,7 +8939,7 @@ char CPyDef_convert_____top_level__(void) {
     CPy_INCREF(CPyModule_builtins);
     CPy_DECREF(cpy_r_r4);
 CPyL3: ;
-    cpy_r_r5 = CPyStatics[513]; /* ('lru_cache',) */
+    cpy_r_r5 = CPyStatics[514]; /* ('lru_cache',) */
     cpy_r_r6 = CPyStatics[32]; /* 'functools' */
     cpy_r_r7 = CPyStatic_convert___globals;
     cpy_r_r8 = CPyImport_ImportFromMany(cpy_r_r6, cpy_r_r5, cpy_r_r5, cpy_r_r7);
@@ -8841,7 +8950,7 @@ CPyL3: ;
     CPyModule_functools = cpy_r_r8;
     CPy_INCREF(CPyModule_functools);
     CPy_DECREF(cpy_r_r8);
-    cpy_r_r9 = CPyStatics[514]; /* ('Final', 'Optional', 'Set') */
+    cpy_r_r9 = CPyStatics[515]; /* ('Final', 'Optional', 'Set') */
     cpy_r_r10 = CPyStatics[37]; /* 'typing' */
     cpy_r_r11 = CPyStatic_convert___globals;
     cpy_r_r12 = CPyImport_ImportFromMany(cpy_r_r10, cpy_r_r9, cpy_r_r9, cpy_r_r11);
@@ -8859,16 +8968,16 @@ CPyL3: ;
     cpy_r_r17 = (void *)&cpy_r_r16;
     int64_t cpy_r_r18[3] = {4, 5, 6};
     cpy_r_r19 = (void *)&cpy_r_r18;
-    cpy_r_r20 = CPyStatics[518]; /* (('a_sync', 'a_sync', 'a_sync'),
+    cpy_r_r20 = CPyStatics[519]; /* (('a_sync', 'a_sync', 'a_sync'),
                                     ('cchecksum', 'cchecksum', 'cchecksum'),
                                     ('hexbytes', 'hexbytes', 'hexbytes')) */
     cpy_r_r21 = CPyStatic_convert___globals;
-    cpy_r_r22 = CPyStatics[155]; /* 'y/convert.py' */
+    cpy_r_r22 = CPyStatics[157]; /* 'y/convert.py' */
     cpy_r_r23 = CPyStatics[31]; /* '<module>' */
     cpy_r_r24 = CPyImport_ImportMany(cpy_r_r20, cpy_r_r17, cpy_r_r21, cpy_r_r22, cpy_r_r23, cpy_r_r19);
     if (!cpy_r_r24) goto CPyL29;
-    cpy_r_r25 = CPyStatics[519]; /* ('AnyAddress', 'ChecksumAddress', 'HexAddress') */
-    cpy_r_r26 = CPyStatics[159]; /* 'eth_typing' */
+    cpy_r_r25 = CPyStatics[520]; /* ('AnyAddress', 'ChecksumAddress', 'HexAddress') */
+    cpy_r_r26 = CPyStatics[161]; /* 'eth_typing' */
     cpy_r_r27 = CPyStatic_convert___globals;
     cpy_r_r28 = CPyImport_ImportFromMany(cpy_r_r26, cpy_r_r25, cpy_r_r25, cpy_r_r27);
     if (unlikely(cpy_r_r28 == NULL)) {
@@ -8878,9 +8987,9 @@ CPyL3: ;
     CPyModule_eth_typing = cpy_r_r28;
     CPy_INCREF(CPyModule_eth_typing);
     CPy_DECREF(cpy_r_r28);
-    cpy_r_r29 = CPyStatics[507]; /* ('ENVIRONMENT_VARIABLES',) */
-    cpy_r_r30 = CPyStatics[508]; /* ('ENVS',) */
-    cpy_r_r31 = CPyStatics[99]; /* 'y' */
+    cpy_r_r29 = CPyStatics[501]; /* ('ENVIRONMENT_VARIABLES',) */
+    cpy_r_r30 = CPyStatics[502]; /* ('ENVS',) */
+    cpy_r_r31 = CPyStatics[48]; /* 'y' */
     cpy_r_r32 = CPyStatic_convert___globals;
     cpy_r_r33 = CPyImport_ImportFromMany(cpy_r_r31, cpy_r_r29, cpy_r_r30, cpy_r_r32);
     if (unlikely(cpy_r_r33 == NULL)) {
@@ -8890,8 +8999,8 @@ CPyL3: ;
     CPyModule_y = cpy_r_r33;
     CPy_INCREF(CPyModule_y);
     CPy_DECREF(cpy_r_r33);
-    cpy_r_r34 = CPyStatics[520]; /* ('AnyAddressType',) */
-    cpy_r_r35 = CPyStatics[161]; /* 'y.datatypes' */
+    cpy_r_r34 = CPyStatics[521]; /* ('AnyAddressType',) */
+    cpy_r_r35 = CPyStatics[163]; /* 'y.datatypes' */
     cpy_r_r36 = CPyStatic_convert___globals;
     cpy_r_r37 = CPyImport_ImportFromMany(cpy_r_r35, cpy_r_r34, cpy_r_r34, cpy_r_r36);
     if (unlikely(cpy_r_r37 == NULL)) {
@@ -8902,7 +9011,7 @@ CPyL3: ;
     CPy_INCREF(CPyModule_y___datatypes);
     CPy_DECREF(cpy_r_r37);
     cpy_r_r38 = CPyModule_hexbytes;
-    cpy_r_r39 = CPyStatics[148]; /* 'HexBytes' */
+    cpy_r_r39 = CPyStatics[150]; /* 'HexBytes' */
     cpy_r_r40 = CPyObject_GetAttr(cpy_r_r38, cpy_r_r39);
     if (unlikely(cpy_r_r40 == NULL)) {
         CPy_AddTraceback("y/convert.py", "<module>", 13, CPyStatic_convert___globals);
@@ -8911,7 +9020,7 @@ CPyL3: ;
     CPyStatic_convert___HexBytes = cpy_r_r40;
     CPy_INCREF(CPyStatic_convert___HexBytes);
     cpy_r_r41 = CPyStatic_convert___globals;
-    cpy_r_r42 = CPyStatics[148]; /* 'HexBytes' */
+    cpy_r_r42 = CPyStatics[150]; /* 'HexBytes' */
     cpy_r_r43 = CPyDict_SetItem(cpy_r_r41, cpy_r_r42, cpy_r_r40);
     CPy_DECREF(cpy_r_r40);
     cpy_r_r44 = cpy_r_r43 >= 0;
@@ -8920,7 +9029,7 @@ CPyL3: ;
         goto CPyL29;
     }
     cpy_r_r45 = CPyModule_cchecksum;
-    cpy_r_r46 = CPyStatics[162]; /* 'to_checksum_address' */
+    cpy_r_r46 = CPyStatics[164]; /* 'to_checksum_address' */
     cpy_r_r47 = CPyObject_GetAttr(cpy_r_r45, cpy_r_r46);
     if (unlikely(cpy_r_r47 == NULL)) {
         CPy_AddTraceback("y/convert.py", "<module>", 15, CPyStatic_convert___globals);
@@ -8929,7 +9038,7 @@ CPyL3: ;
     CPyStatic_convert___to_checksum_address = cpy_r_r47;
     CPy_INCREF(CPyStatic_convert___to_checksum_address);
     cpy_r_r48 = CPyStatic_convert___globals;
-    cpy_r_r49 = CPyStatics[162]; /* 'to_checksum_address' */
+    cpy_r_r49 = CPyStatics[164]; /* 'to_checksum_address' */
     cpy_r_r50 = CPyDict_SetItem(cpy_r_r48, cpy_r_r49, cpy_r_r47);
     CPy_DECREF(cpy_r_r47);
     cpy_r_r51 = cpy_r_r50 >= 0;
@@ -8938,7 +9047,7 @@ CPyL3: ;
         goto CPyL29;
     }
     cpy_r_r52 = CPyStatic_convert___globals;
-    cpy_r_r53 = CPyStatics[143]; /* 'checksum' */
+    cpy_r_r53 = CPyStatics[145]; /* 'checksum' */
     cpy_r_r54 = CPyDict_GetItem(cpy_r_r52, cpy_r_r53);
     if (unlikely(cpy_r_r54 == NULL)) {
         CPy_AddTraceback("y/convert.py", "<module>", 18, CPyStatic_convert___globals);
@@ -8967,7 +9076,7 @@ CPyL17: ;
     }
     PyObject *cpy_r_r60[1] = {cpy_r_r55};
     cpy_r_r61 = (PyObject **)&cpy_r_r60;
-    cpy_r_r62 = CPyStatics[489]; /* ('maxsize',) */
+    cpy_r_r62 = CPyStatics[490]; /* ('maxsize',) */
     cpy_r_r63 = PyObject_Vectorcall(cpy_r_r59, cpy_r_r61, 0, cpy_r_r62);
     CPy_DECREF(cpy_r_r59);
     if (unlikely(cpy_r_r63 == NULL)) {
@@ -8984,7 +9093,7 @@ CPyL17: ;
     }
     CPy_DECREF(cpy_r_r54);
     cpy_r_r67 = CPyStatic_convert___globals;
-    cpy_r_r68 = CPyStatics[143]; /* 'checksum' */
+    cpy_r_r68 = CPyStatics[145]; /* 'checksum' */
     cpy_r_r69 = CPyDict_SetItem(cpy_r_r67, cpy_r_r68, cpy_r_r66);
     CPy_DECREF(cpy_r_r66);
     cpy_r_r70 = cpy_r_r69 >= 0;
@@ -8993,13 +9102,13 @@ CPyL17: ;
         goto CPyL29;
     }
     cpy_r_r71 = CPyModule_a_sync;
-    cpy_r_r72 = CPyStatics[163]; /* 'ThreadPoolExecutor' */
+    cpy_r_r72 = CPyStatics[165]; /* 'ThreadPoolExecutor' */
     cpy_r_r73 = CPyObject_GetAttr(cpy_r_r71, cpy_r_r72);
     if (unlikely(cpy_r_r73 == NULL)) {
         CPy_AddTraceback("y/convert.py", "<module>", 75, CPyStatic_convert___globals);
         goto CPyL29;
     }
-    cpy_r_r74 = CPyStatics[472]; /* 1 */
+    cpy_r_r74 = CPyStatics[473]; /* 1 */
     PyObject *cpy_r_r75[1] = {cpy_r_r74};
     cpy_r_r76 = (PyObject **)&cpy_r_r75;
     cpy_r_r77 = PyObject_Vectorcall(cpy_r_r73, cpy_r_r76, 1, 0);
@@ -9011,7 +9120,7 @@ CPyL17: ;
     CPyStatic_convert____checksum_thread = cpy_r_r77;
     CPy_INCREF(CPyStatic_convert____checksum_thread);
     cpy_r_r78 = CPyStatic_convert___globals;
-    cpy_r_r79 = CPyStatics[164]; /* '_checksum_thread' */
+    cpy_r_r79 = CPyStatics[166]; /* '_checksum_thread' */
     cpy_r_r80 = CPyDict_SetItem(cpy_r_r78, cpy_r_r79, cpy_r_r77);
     CPy_DECREF(cpy_r_r77);
     cpy_r_r81 = cpy_r_r80 >= 0;
@@ -9027,7 +9136,7 @@ CPyL17: ;
     CPyStatic_convert____is_checksummed = cpy_r_r82;
     CPy_INCREF(CPyStatic_convert____is_checksummed);
     cpy_r_r83 = CPyStatic_convert___globals;
-    cpy_r_r84 = CPyStatics[165]; /* '_is_checksummed' */
+    cpy_r_r84 = CPyStatics[167]; /* '_is_checksummed' */
     cpy_r_r85 = CPyDict_SetItem(cpy_r_r83, cpy_r_r84, cpy_r_r82);
     CPy_DECREF(cpy_r_r82);
     cpy_r_r86 = cpy_r_r85 >= 0;
@@ -9043,7 +9152,7 @@ CPyL17: ;
     CPyStatic_convert____is_not_checksummed = cpy_r_r87;
     CPy_INCREF(CPyStatic_convert____is_not_checksummed);
     cpy_r_r88 = CPyStatic_convert___globals;
-    cpy_r_r89 = CPyStatics[166]; /* '_is_not_checksummed' */
+    cpy_r_r89 = CPyStatics[168]; /* '_is_not_checksummed' */
     cpy_r_r90 = CPyDict_SetItem(cpy_r_r88, cpy_r_r89, cpy_r_r87);
     CPy_DECREF(cpy_r_r87);
     cpy_r_r91 = cpy_r_r90 >= 0;
@@ -10002,28 +10111,28 @@ char CPyDef_exceptions___yPriceMagicError_____init__(PyObject *cpy_r_self, PyObj
     PyObject **cpy_r_r52;
     PyObject *cpy_r_r53;
     char cpy_r_r54;
-    cpy_r_r0 = CPyStatics[167]; /* 'token' */
+    cpy_r_r0 = CPyStatics[169]; /* 'token' */
     cpy_r_r1 = PyObject_SetAttr(cpy_r_self, cpy_r_r0, cpy_r_token_address);
     cpy_r_r2 = cpy_r_r1 >= 0;
     if (unlikely(!cpy_r_r2)) {
         CPy_AddTraceback("y/exceptions.py", "__init__", 38, CPyStatic_exceptions___globals);
         goto CPyL23;
     }
-    cpy_r_r3 = CPyStatics[168]; /* 'block' */
+    cpy_r_r3 = CPyStatics[170]; /* 'block' */
     cpy_r_r4 = PyObject_SetAttr(cpy_r_self, cpy_r_r3, cpy_r_block);
     cpy_r_r5 = cpy_r_r4 >= 0;
     if (unlikely(!cpy_r_r5)) {
         CPy_AddTraceback("y/exceptions.py", "__init__", 43, CPyStatic_exceptions___globals);
         goto CPyL23;
     }
-    cpy_r_r6 = CPyStatics[169]; /* 'exception' */
+    cpy_r_r6 = CPyStatics[171]; /* 'exception' */
     cpy_r_r7 = PyObject_SetAttr(cpy_r_self, cpy_r_r6, cpy_r_exc);
     cpy_r_r8 = cpy_r_r7 >= 0;
     if (unlikely(!cpy_r_r8)) {
         CPy_AddTraceback("y/exceptions.py", "__init__", 48, CPyStatic_exceptions___globals);
         goto CPyL23;
     }
-    cpy_r_r9 = CPyStatics[170]; /* '__class__' */
+    cpy_r_r9 = CPyStatics[172]; /* '__class__' */
     cpy_r_r10 = CPyObject_GetAttr(cpy_r_exc, cpy_r_r9);
     if (unlikely(cpy_r_r10 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "__init__", 53, CPyStatic_exceptions___globals);
@@ -10043,7 +10152,7 @@ char CPyDef_exceptions___yPriceMagicError_____init__(PyObject *cpy_r_self, PyObj
         goto CPyL23;
     }
     cpy_r_detail = cpy_r_r13;
-    cpy_r_r14 = CPyStatics[169]; /* 'exception' */
+    cpy_r_r14 = CPyStatics[171]; /* 'exception' */
     cpy_r_r15 = CPyObject_GetAttr(cpy_r_self, cpy_r_r14);
     if (unlikely(cpy_r_r15 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "__init__", 54, CPyStatic_exceptions___globals);
@@ -10055,13 +10164,13 @@ char CPyDef_exceptions___yPriceMagicError_____init__(PyObject *cpy_r_self, PyObj
     CPy_DECREF(cpy_r_r15);
     cpy_r_r19 = cpy_r_r18 == cpy_r_r16;
     if (cpy_r_r19) goto CPyL12;
-    cpy_r_r20 = CPyStatics[77]; /* '(' */
+    cpy_r_r20 = CPyStatics[82]; /* '(' */
     cpy_r_r21 = PyObject_Str(cpy_r_exc);
     if (unlikely(cpy_r_r21 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "__init__", 55, CPyStatic_exceptions___globals);
         goto CPyL24;
     }
-    cpy_r_r22 = CPyStatics[79]; /* ')' */
+    cpy_r_r22 = CPyStatics[84]; /* ')' */
     cpy_r_r23 = CPyStr_Build(3, cpy_r_r20, cpy_r_r21, cpy_r_r22);
     CPy_DECREF(cpy_r_r21);
     if (unlikely(cpy_r_r23 == NULL)) {
@@ -10076,8 +10185,8 @@ char CPyDef_exceptions___yPriceMagicError_____init__(PyObject *cpy_r_self, PyObj
     }
     cpy_r_detail = cpy_r_r24;
 CPyL12: ;
-    cpy_r_r25 = CPyStatics[521]; /* ('Network',) */
-    cpy_r_r26 = CPyStatics[99]; /* 'y' */
+    cpy_r_r25 = CPyStatics[522]; /* ('Network',) */
+    cpy_r_r26 = CPyStatics[48]; /* 'y' */
     cpy_r_r27 = CPyStatic_exceptions___globals;
     cpy_r_r28 = CPyImport_ImportFromMany(cpy_r_r26, cpy_r_r25, cpy_r_r25, cpy_r_r27);
     if (unlikely(cpy_r_r28 == NULL)) {
@@ -10088,7 +10197,7 @@ CPyL12: ;
     CPy_INCREF(CPyModule_y);
     CPy_DECREF(cpy_r_r28);
     cpy_r_r29 = CPyModule_builtins;
-    cpy_r_r30 = CPyStatics[172]; /* 'super' */
+    cpy_r_r30 = CPyStatics[174]; /* 'super' */
     cpy_r_r31 = CPyObject_GetAttr(cpy_r_r29, cpy_r_r30);
     if (unlikely(cpy_r_r31 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "__init__", 59, CPyStatic_exceptions___globals);
@@ -10103,16 +10212,16 @@ CPyL12: ;
         CPy_AddTraceback("y/exceptions.py", "__init__", 59, CPyStatic_exceptions___globals);
         goto CPyL24;
     }
-    cpy_r_r36 = CPyStatics[173]; /* '__init__' */
+    cpy_r_r36 = CPyStatics[175]; /* '__init__' */
     cpy_r_r37 = CPyObject_GetAttr(cpy_r_r35, cpy_r_r36);
     CPy_DECREF(cpy_r_r35);
     if (unlikely(cpy_r_r37 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "__init__", 59, CPyStatic_exceptions___globals);
         goto CPyL24;
     }
-    cpy_r_r38 = CPyStatics[174]; /* ' while fetching ' */
+    cpy_r_r38 = CPyStatics[176]; /* ' while fetching ' */
     cpy_r_r39 = (PyObject *)CPyType_networks___Network;
-    cpy_r_r40 = CPyStatics[175]; /* 'printable' */
+    cpy_r_r40 = CPyStatics[177]; /* 'printable' */
     PyObject *cpy_r_r41[1] = {cpy_r_r39};
     cpy_r_r42 = (PyObject **)&cpy_r_r41;
     cpy_r_r43 = PyObject_VectorcallMethod(cpy_r_r40, cpy_r_r42, 9223372036854775809ULL, 0);
@@ -10133,7 +10242,7 @@ CPyL12: ;
         CPy_AddTraceback("y/exceptions.py", "__init__", 60, CPyStatic_exceptions___globals);
         goto CPyL26;
     }
-    cpy_r_r48 = CPyStatics[176]; /* ' at block ' */
+    cpy_r_r48 = CPyStatics[178]; /* ' at block ' */
     cpy_r_r49 = PyObject_Str(cpy_r_block);
     if (unlikely(cpy_r_r49 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "__init__", 60, CPyStatic_exceptions___globals);
@@ -10265,7 +10374,7 @@ char CPyDef_exceptions___PriceError_____init__(PyObject *cpy_r_self, PyObject *c
     PyObject *cpy_r_r21;
     char cpy_r_r22;
     cpy_r_r0 = CPyModule_builtins;
-    cpy_r_r1 = CPyStatics[172]; /* 'super' */
+    cpy_r_r1 = CPyStatics[174]; /* 'super' */
     cpy_r_r2 = CPyObject_GetAttr(cpy_r_r0, cpy_r_r1);
     if (unlikely(cpy_r_r2 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "__init__", 71, CPyStatic_exceptions___globals);
@@ -10280,16 +10389,16 @@ char CPyDef_exceptions___PriceError_____init__(PyObject *cpy_r_self, PyObject *c
         CPy_AddTraceback("y/exceptions.py", "__init__", 71, CPyStatic_exceptions___globals);
         goto CPyL10;
     }
-    cpy_r_r7 = CPyStatics[173]; /* '__init__' */
+    cpy_r_r7 = CPyStatics[175]; /* '__init__' */
     cpy_r_r8 = CPyObject_GetAttr(cpy_r_r6, cpy_r_r7);
     CPy_DECREF(cpy_r_r6);
     if (unlikely(cpy_r_r8 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "__init__", 71, CPyStatic_exceptions___globals);
         goto CPyL10;
     }
-    cpy_r_r9 = CPyStatics[177]; /* 'No price found for ' */
+    cpy_r_r9 = CPyStatics[179]; /* 'No price found for ' */
     cpy_r_r10 = CPyStatics[23]; /* ' ' */
-    cpy_r_r11 = CPyStatics[178]; /* 'address' */
+    cpy_r_r11 = CPyStatics[180]; /* 'address' */
     cpy_r_r12 = CPyObject_GetAttr(cpy_r_logger, cpy_r_r11);
     if (unlikely(cpy_r_r12 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "__init__", 71, CPyStatic_exceptions___globals);
@@ -10301,8 +10410,8 @@ char CPyDef_exceptions___PriceError_____init__(PyObject *cpy_r_self, PyObject *c
         CPy_AddTraceback("y/exceptions.py", "__init__", 71, CPyStatic_exceptions___globals);
         goto CPyL11;
     }
-    cpy_r_r14 = CPyStatics[176]; /* ' at block ' */
-    cpy_r_r15 = CPyStatics[168]; /* 'block' */
+    cpy_r_r14 = CPyStatics[178]; /* ' at block ' */
+    cpy_r_r15 = CPyStatics[170]; /* 'block' */
     cpy_r_r16 = CPyObject_GetAttr(cpy_r_logger, cpy_r_r15);
     if (unlikely(cpy_r_r16 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "__init__", 71, CPyStatic_exceptions___globals);
@@ -10407,7 +10516,7 @@ char CPyDef_exceptions___TokenError_____init__(PyObject *cpy_r_self, PyObject *c
     PyObject *cpy_r_r18;
     char cpy_r_r19;
     cpy_r_r0 = CPyModule_builtins;
-    cpy_r_r1 = CPyStatics[172]; /* 'super' */
+    cpy_r_r1 = CPyStatics[174]; /* 'super' */
     cpy_r_r2 = CPyObject_GetAttr(cpy_r_r0, cpy_r_r1);
     if (unlikely(cpy_r_r2 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "__init__", 98, CPyStatic_exceptions___globals);
@@ -10422,7 +10531,7 @@ char CPyDef_exceptions___TokenError_____init__(PyObject *cpy_r_self, PyObject *c
         CPy_AddTraceback("y/exceptions.py", "__init__", 98, CPyStatic_exceptions___globals);
         goto CPyL11;
     }
-    cpy_r_r7 = CPyStatics[173]; /* '__init__' */
+    cpy_r_r7 = CPyStatics[175]; /* '__init__' */
     cpy_r_r8 = CPyObject_GetAttr(cpy_r_r6, cpy_r_r7);
     CPy_DECREF(cpy_r_r6);
     if (unlikely(cpy_r_r8 == NULL)) {
@@ -10434,7 +10543,7 @@ char CPyDef_exceptions___TokenError_____init__(PyObject *cpy_r_self, PyObject *c
         CPy_AddTraceback("y/exceptions.py", "__init__", 98, CPyStatic_exceptions___globals);
         goto CPyL12;
     }
-    cpy_r_r10 = CPyStatics[179]; /* ' is not a ' */
+    cpy_r_r10 = CPyStatics[181]; /* ' is not a ' */
     cpy_r_r11 = CPyStr_Build(3, cpy_r_r9, cpy_r_r10, cpy_r_desired_type);
     CPy_DECREF(cpy_r_r9);
     if (unlikely(cpy_r_r11 == NULL)) {
@@ -10579,12 +10688,12 @@ char CPyDef_exceptions___InvalidAPIKeyError_____init__(PyObject *cpy_r_self, PyO
     PyObject *cpy_r_r17;
     char cpy_r_r18;
     if (cpy_r_msg != NULL) goto CPyL13;
-    cpy_r_r0 = CPyStatics[133]; /* '' */
+    cpy_r_r0 = CPyStatics[135]; /* '' */
     CPy_INCREF(cpy_r_r0);
     cpy_r_msg = cpy_r_r0;
 CPyL2: ;
     cpy_r_r1 = CPyModule_builtins;
-    cpy_r_r2 = CPyStatics[172]; /* 'super' */
+    cpy_r_r2 = CPyStatics[174]; /* 'super' */
     cpy_r_r3 = CPyObject_GetAttr(cpy_r_r1, cpy_r_r2);
     if (unlikely(cpy_r_r3 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "__init__", 122, CPyStatic_exceptions___globals);
@@ -10599,7 +10708,7 @@ CPyL2: ;
         CPy_AddTraceback("y/exceptions.py", "__init__", 122, CPyStatic_exceptions___globals);
         goto CPyL14;
     }
-    cpy_r_r8 = CPyStatics[173]; /* '__init__' */
+    cpy_r_r8 = CPyStatics[175]; /* '__init__' */
     cpy_r_r9 = CPyObject_GetAttr(cpy_r_r7, cpy_r_r8);
     CPy_DECREF(cpy_r_r7);
     if (unlikely(cpy_r_r9 == NULL)) {
@@ -10611,7 +10720,7 @@ CPyL2: ;
     cpy_r_r11 = cpy_r_msg;
     goto CPyL10;
 CPyL7: ;
-    cpy_r_r12 = CPyStatics[180]; /* '_msg' */
+    cpy_r_r12 = CPyStatics[182]; /* '_msg' */
     cpy_r_r13 = CPyObject_GetAttr(cpy_r_self, cpy_r_r12);
     if (unlikely(cpy_r_r13 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "__init__", 122, CPyStatic_exceptions___globals);
@@ -10749,7 +10858,7 @@ char CPyDef_exceptions___MessedUpBrownieContract_____init__(PyObject *cpy_r_self
     char cpy_r_r52;
     char cpy_r_r53;
     cpy_r_r0 = CPyModule_builtins;
-    cpy_r_r1 = CPyStatics[172]; /* 'super' */
+    cpy_r_r1 = CPyStatics[174]; /* 'super' */
     cpy_r_r2 = CPyObject_GetAttr(cpy_r_r0, cpy_r_r1);
     if (unlikely(cpy_r_r2 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "__init__", 153, CPyStatic_exceptions___globals);
@@ -10764,7 +10873,7 @@ char CPyDef_exceptions___MessedUpBrownieContract_____init__(PyObject *cpy_r_self
         CPy_AddTraceback("y/exceptions.py", "__init__", 153, CPyStatic_exceptions___globals);
         goto CPyL37;
     }
-    cpy_r_r7 = CPyStatics[173]; /* '__init__' */
+    cpy_r_r7 = CPyStatics[175]; /* '__init__' */
     cpy_r_r8 = CPyObject_GetAttr(cpy_r_r6, cpy_r_r7);
     CPy_DECREF(cpy_r_r6);
     if (unlikely(cpy_r_r8 == NULL)) {
@@ -10805,13 +10914,13 @@ CPyL5: ;
         goto CPyL42;
 CPyL8: ;
     cpy_r_r14 = CPyStatic_exceptions___globals;
-    cpy_r_r15 = CPyStatics[181]; /* 'BrownieContract' */
+    cpy_r_r15 = CPyStatics[183]; /* 'BrownieContract' */
     cpy_r_r16 = CPyDict_GetItem(cpy_r_r14, cpy_r_r15);
     if (unlikely(cpy_r_r16 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "__init__", 156, CPyStatic_exceptions___globals);
         goto CPyL11;
     }
-    cpy_r_r17 = CPyStatics[182]; /* 'from_explorer' */
+    cpy_r_r17 = CPyStatics[184]; /* 'from_explorer' */
     PyObject *cpy_r_r18[2] = {cpy_r_r16, cpy_r_address};
     cpy_r_r19 = (PyObject **)&cpy_r_r18;
     cpy_r_r20 = PyObject_VectorcallMethod(cpy_r_r17, cpy_r_r19, 9223372036854775810ULL, 0);
@@ -10826,7 +10935,7 @@ CPyL10: ;
 CPyL11: ;
     cpy_r_r21 = CPy_CatchError();
     cpy_r_r22 = CPyStatic_exceptions___globals;
-    cpy_r_r23 = CPyStatics[183]; /* 'CompilerError' */
+    cpy_r_r23 = CPyStatics[185]; /* 'CompilerError' */
     cpy_r_r24 = CPyDict_GetItem(cpy_r_r22, cpy_r_r23);
     if (unlikely(cpy_r_r24 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "__init__", 157, CPyStatic_exceptions___globals);
@@ -10836,7 +10945,7 @@ CPyL11: ;
     CPy_DecRef(cpy_r_r24);
     if (cpy_r_r25) goto CPyL33;
     cpy_r_r26 = CPyModule_builtins;
-    cpy_r_r27 = CPyStatics[184]; /* 'Exception' */
+    cpy_r_r27 = CPyStatics[186]; /* 'Exception' */
     cpy_r_r28 = CPyObject_GetAttr(cpy_r_r26, cpy_r_r27);
     if (unlikely(cpy_r_r28 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "__init__", 159, CPyStatic_exceptions___globals);
@@ -10846,7 +10955,7 @@ CPyL11: ;
     CPy_DecRef(cpy_r_r28);
     if (!cpy_r_r29) goto CPyL31;
     cpy_r_r30 = CPy_GetExcValue();
-    cpy_r_r31 = CPyStatics[185]; /* "invalid literal for int() with base 16: ''" */
+    cpy_r_r31 = CPyStatics[187]; /* "invalid literal for int() with base 16: ''" */
     cpy_r_r32 = PyObject_Str(cpy_r_r30);
     if (unlikely(cpy_r_r32 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "__init__", 160, CPyStatic_exceptions___globals);
@@ -10861,7 +10970,7 @@ CPyL11: ;
     }
     cpy_r_r35 = cpy_r_r33;
     if (cpy_r_r35) goto CPyL46;
-    cpy_r_r36 = CPyStatics[186]; /* 'list index out of range' */
+    cpy_r_r36 = CPyStatics[188]; /* 'list index out of range' */
     cpy_r_r37 = PyObject_Str(cpy_r_r30);
     if (unlikely(cpy_r_r37 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "__init__", 162, CPyStatic_exceptions___globals);
@@ -10876,7 +10985,7 @@ CPyL11: ;
     }
     cpy_r_r40 = cpy_r_r38;
     if (cpy_r_r40) goto CPyL46;
-    cpy_r_r41 = CPyStatics[187]; /* 'pop from an empty deque' */
+    cpy_r_r41 = CPyStatics[189]; /* 'pop from an empty deque' */
     cpy_r_r42 = PyObject_Str(cpy_r_r30);
     if (unlikely(cpy_r_r42 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "__init__", 164, CPyStatic_exceptions___globals);
@@ -10891,7 +11000,7 @@ CPyL11: ;
     }
     cpy_r_r45 = cpy_r_r43;
     if (cpy_r_r45) goto CPyL46;
-    cpy_r_r46 = CPyStatics[188]; /* "'UsingForDirective' object has no attribute 'typeName'" */
+    cpy_r_r46 = CPyStatics[190]; /* "'UsingForDirective' object has no attribute 'typeName'" */
     cpy_r_r47 = PyObject_Str(cpy_r_r30);
     if (unlikely(cpy_r_r47 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "__init__", 166, CPyStatic_exceptions___globals);
@@ -11033,8 +11142,8 @@ char CPyDef_exceptions___contract_not_verified(PyObject *cpy_r_e) {
     char cpy_r_r10;
     char cpy_r_r11;
     char cpy_r_r12;
-    cpy_r_r0 = CPyStatics[189]; /* 'Contract source code not verified' */
-    cpy_r_r1 = CPyStatics[190]; /* 'has not been verified' */
+    cpy_r_r0 = CPyStatics[191]; /* 'Contract source code not verified' */
+    cpy_r_r1 = CPyStatics[192]; /* 'has not been verified' */
     CPy_INCREF(cpy_r_r0);
     CPy_INCREF(cpy_r_r1);
     cpy_r_r2.f0 = cpy_r_r0;
@@ -11175,8 +11284,8 @@ char CPyDef_exceptions___NotAUniswapV2Pool_____init__(PyObject *cpy_r_self, PyOb
     PyObject **cpy_r_r44;
     PyObject *cpy_r_r45;
     char cpy_r_r46;
-    cpy_r_r0 = CPyStatics[522]; /* ('UniswapV2Pool',) */
-    cpy_r_r1 = CPyStatics[192]; /* 'y.prices.dex.uniswap.v2' */
+    cpy_r_r0 = CPyStatics[523]; /* ('UniswapV2Pool',) */
+    cpy_r_r1 = CPyStatics[194]; /* 'y.prices.dex.uniswap.v2' */
     cpy_r_r2 = CPyStatic_exceptions___globals;
     cpy_r_r3 = CPyImport_ImportFromMany(cpy_r_r1, cpy_r_r0, cpy_r_r0, cpy_r_r2);
     if (unlikely(cpy_r_r3 == NULL)) {
@@ -11187,13 +11296,13 @@ char CPyDef_exceptions___NotAUniswapV2Pool_____init__(PyObject *cpy_r_self, PyOb
     CPy_INCREF(CPyModule_y___prices___dex___uniswap___v2);
     CPy_DECREF(cpy_r_r3);
     cpy_r_r4 = CPyStatic_exceptions___globals;
-    cpy_r_r5 = CPyStatics[191]; /* 'UniswapV2Pool' */
+    cpy_r_r5 = CPyStatics[193]; /* 'UniswapV2Pool' */
     cpy_r_r6 = CPyDict_GetItem(cpy_r_r4, cpy_r_r5);
     if (unlikely(cpy_r_r6 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "__init__", 200, CPyStatic_exceptions___globals);
         goto CPyL17;
     }
-    cpy_r_r7 = CPyStatics[193]; /* '_ChecksumASyncSingletonMeta__instances' */
+    cpy_r_r7 = CPyStatics[195]; /* '_ChecksumASyncSingletonMeta__instances' */
     cpy_r_r8 = CPyObject_GetAttr(cpy_r_r6, cpy_r_r7);
     CPy_DECREF(cpy_r_r6);
     if (unlikely(cpy_r_r8 == NULL)) {
@@ -11207,13 +11316,13 @@ char CPyDef_exceptions___NotAUniswapV2Pool_____init__(PyObject *cpy_r_self, PyOb
         CPy_AddTraceback("y/exceptions.py", "__init__", 200, CPyStatic_exceptions___globals);
         goto CPyL17;
     }
-    cpy_r_r11 = CPyStatics[178]; /* 'address' */
+    cpy_r_r11 = CPyStatics[180]; /* 'address' */
     cpy_r_r12 = CPyObject_GetAttr(cpy_r_non_pool, cpy_r_r11);
     if (unlikely(cpy_r_r12 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "__init__", 200, CPyStatic_exceptions___globals);
         goto CPyL18;
     }
-    cpy_r_r13 = CPyStatics[194]; /* 'pop' */
+    cpy_r_r13 = CPyStatics[196]; /* 'pop' */
     cpy_r_r14 = Py_None;
     PyObject *cpy_r_r15[3] = {cpy_r_r10, cpy_r_r12, cpy_r_r14};
     cpy_r_r16 = (PyObject **)&cpy_r_r15;
@@ -11227,13 +11336,13 @@ CPyL6: ;
     CPy_DECREF(cpy_r_r10);
     CPy_DECREF(cpy_r_r12);
     cpy_r_r18 = CPyStatic_exceptions___globals;
-    cpy_r_r19 = CPyStatics[191]; /* 'UniswapV2Pool' */
+    cpy_r_r19 = CPyStatics[193]; /* 'UniswapV2Pool' */
     cpy_r_r20 = CPyDict_GetItem(cpy_r_r18, cpy_r_r19);
     if (unlikely(cpy_r_r20 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "__init__", 201, CPyStatic_exceptions___globals);
         goto CPyL17;
     }
-    cpy_r_r21 = CPyStatics[193]; /* '_ChecksumASyncSingletonMeta__instances' */
+    cpy_r_r21 = CPyStatics[195]; /* '_ChecksumASyncSingletonMeta__instances' */
     cpy_r_r22 = CPyObject_GetAttr(cpy_r_r20, cpy_r_r21);
     CPy_DECREF(cpy_r_r20);
     if (unlikely(cpy_r_r22 == NULL)) {
@@ -11247,13 +11356,13 @@ CPyL6: ;
         CPy_AddTraceback("y/exceptions.py", "__init__", 201, CPyStatic_exceptions___globals);
         goto CPyL17;
     }
-    cpy_r_r25 = CPyStatics[178]; /* 'address' */
+    cpy_r_r25 = CPyStatics[180]; /* 'address' */
     cpy_r_r26 = CPyObject_GetAttr(cpy_r_non_pool, cpy_r_r25);
     if (unlikely(cpy_r_r26 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "__init__", 201, CPyStatic_exceptions___globals);
         goto CPyL21;
     }
-    cpy_r_r27 = CPyStatics[194]; /* 'pop' */
+    cpy_r_r27 = CPyStatics[196]; /* 'pop' */
     cpy_r_r28 = Py_None;
     PyObject *cpy_r_r29[3] = {cpy_r_r24, cpy_r_r26, cpy_r_r28};
     cpy_r_r30 = (PyObject **)&cpy_r_r29;
@@ -11267,7 +11376,7 @@ CPyL11: ;
     CPy_DECREF(cpy_r_r24);
     CPy_DECREF(cpy_r_r26);
     cpy_r_r32 = CPyModule_builtins;
-    cpy_r_r33 = CPyStatics[172]; /* 'super' */
+    cpy_r_r33 = CPyStatics[174]; /* 'super' */
     cpy_r_r34 = CPyObject_GetAttr(cpy_r_r32, cpy_r_r33);
     if (unlikely(cpy_r_r34 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "__init__", 202, CPyStatic_exceptions___globals);
@@ -11282,14 +11391,14 @@ CPyL11: ;
         CPy_AddTraceback("y/exceptions.py", "__init__", 202, CPyStatic_exceptions___globals);
         goto CPyL17;
     }
-    cpy_r_r39 = CPyStatics[173]; /* '__init__' */
+    cpy_r_r39 = CPyStatics[175]; /* '__init__' */
     cpy_r_r40 = CPyObject_GetAttr(cpy_r_r38, cpy_r_r39);
     CPy_DECREF(cpy_r_r38);
     if (unlikely(cpy_r_r40 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "__init__", 202, CPyStatic_exceptions___globals);
         goto CPyL17;
     }
-    cpy_r_r41 = CPyStatics[178]; /* 'address' */
+    cpy_r_r41 = CPyStatics[180]; /* 'address' */
     cpy_r_r42 = CPyObject_GetAttr(cpy_r_non_pool, cpy_r_r41);
     if (unlikely(cpy_r_r42 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "__init__", 202, CPyStatic_exceptions___globals);
@@ -11385,7 +11494,7 @@ char CPyDef_exceptions___TokenNotFound_____init__(PyObject *cpy_r_self, PyObject
     PyObject *cpy_r_r15;
     char cpy_r_r16;
     cpy_r_r0 = CPyModule_builtins;
-    cpy_r_r1 = CPyStatics[172]; /* 'super' */
+    cpy_r_r1 = CPyStatics[174]; /* 'super' */
     cpy_r_r2 = CPyObject_GetAttr(cpy_r_r0, cpy_r_r1);
     if (unlikely(cpy_r_r2 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "__init__", 229, CPyStatic_exceptions___globals);
@@ -11400,7 +11509,7 @@ char CPyDef_exceptions___TokenNotFound_____init__(PyObject *cpy_r_self, PyObject
         CPy_AddTraceback("y/exceptions.py", "__init__", 229, CPyStatic_exceptions___globals);
         goto CPyL8;
     }
-    cpy_r_r7 = CPyStatics[173]; /* '__init__' */
+    cpy_r_r7 = CPyStatics[175]; /* '__init__' */
     cpy_r_r8 = CPyObject_GetAttr(cpy_r_r6, cpy_r_r7);
     CPy_DECREF(cpy_r_r6);
     if (unlikely(cpy_r_r8 == NULL)) {
@@ -11412,7 +11521,7 @@ char CPyDef_exceptions___TokenNotFound_____init__(PyObject *cpy_r_self, PyObject
         CPy_AddTraceback("y/exceptions.py", "__init__", 229, CPyStatic_exceptions___globals);
         goto CPyL9;
     }
-    cpy_r_r10 = CPyStatics[195]; /* ' is not in ' */
+    cpy_r_r10 = CPyStatics[197]; /* ' is not in ' */
     cpy_r_r11 = PyObject_Str(cpy_r_container);
     if (unlikely(cpy_r_r11 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "__init__", 229, CPyStatic_exceptions___globals);
@@ -11503,7 +11612,7 @@ char CPyDef_exceptions___call_reverted(PyObject *cpy_r_e) {
     char cpy_r_r21;
     char cpy_r_r22;
     cpy_r_r0 = CPyStatic_exceptions___globals;
-    cpy_r_r1 = CPyStatics[196]; /* 'ContractLogicError' */
+    cpy_r_r1 = CPyStatics[198]; /* 'ContractLogicError' */
     cpy_r_r2 = CPyDict_GetItem(cpy_r_r0, cpy_r_r1);
     if (unlikely(cpy_r_r2 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "call_reverted", 250, CPyStatic_exceptions___globals);
@@ -11520,12 +11629,12 @@ char CPyDef_exceptions___call_reverted(PyObject *cpy_r_e) {
     if (!cpy_r_r5) goto CPyL4;
     return 1;
 CPyL4: ;
-    cpy_r_r6 = CPyStatics[197]; /* 'execution reverted' */
-    cpy_r_r7 = CPyStatics[198]; /* 'No data was returned - the call likely reverted' */
-    cpy_r_r8 = CPyStatics[199]; /* 'invalid opcode: opcode 0xfe not defined' */
-    cpy_r_r9 = CPyStatics[200]; /* 'Tried to read 32 bytes.  Only got 0 bytes' */
-    cpy_r_r10 = CPyStatics[201]; /* 'error processing call Revert' */
-    cpy_r_r11 = CPyStatics[202]; /* 'invalid opcode: INVALID' */
+    cpy_r_r6 = CPyStatics[199]; /* 'execution reverted' */
+    cpy_r_r7 = CPyStatics[200]; /* 'No data was returned - the call likely reverted' */
+    cpy_r_r8 = CPyStatics[201]; /* 'invalid opcode: opcode 0xfe not defined' */
+    cpy_r_r9 = CPyStatics[202]; /* 'Tried to read 32 bytes.  Only got 0 bytes' */
+    cpy_r_r10 = CPyStatics[203]; /* 'error processing call Revert' */
+    cpy_r_r11 = CPyStatics[204]; /* 'invalid opcode: INVALID' */
     CPy_INCREF(cpy_r_r6);
     CPy_INCREF(cpy_r_r7);
     CPy_INCREF(cpy_r_r8);
@@ -11691,7 +11800,7 @@ char CPyDef_exceptions___out_of_gas(PyObject *cpy_r_e) {
     char cpy_r_r3;
     char cpy_r_r4;
     char cpy_r_r5;
-    cpy_r_r0 = CPyStatics[203]; /* 'out of gas' */
+    cpy_r_r0 = CPyStatics[205]; /* 'out of gas' */
     cpy_r_r1 = PyObject_Str(cpy_r_e);
     if (unlikely(cpy_r_r1 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "out_of_gas", 275, CPyStatic_exceptions___globals);
@@ -11837,7 +11946,7 @@ CPyL10: ;
         goto CPyL28;
     }
     cpy_r_r10 = CPyModule_builtins;
-    cpy_r_r11 = CPyStatics[184]; /* 'Exception' */
+    cpy_r_r11 = CPyStatics[186]; /* 'Exception' */
     cpy_r_r12 = CPyObject_GetAttr(cpy_r_r10, cpy_r_r11);
     if (unlikely(cpy_r_r12 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "reraise_excs_with_extra_context", 290, CPyStatic_exceptions___globals);
@@ -11863,7 +11972,7 @@ CPyL10: ;
     }
     CPy_INCREF(cpy_r_r16);
 CPyL15: ;
-    cpy_r_r17 = CPyStatics[204]; /* 'args' */
+    cpy_r_r17 = CPyStatics[206]; /* 'args' */
     cpy_r_r18 = CPyObject_GetAttr(cpy_r_r16, cpy_r_r17);
     CPy_DecRef(cpy_r_r16);
     if (unlikely(cpy_r_r18 == NULL)) {
@@ -11917,7 +12026,7 @@ CPyL21: ;
     }
     CPy_INCREF(cpy_r_r25);
 CPyL23: ;
-    cpy_r_r26 = CPyStatics[204]; /* 'args' */
+    cpy_r_r26 = CPyStatics[206]; /* 'args' */
     cpy_r_r27 = PyObject_SetAttr(cpy_r_r25, cpy_r_r26, cpy_r_r24);
     CPy_DecRef(cpy_r_r25);
     CPy_DecRef(cpy_r_r24);
@@ -12250,7 +12359,7 @@ PyObject *CPyDef_exceptions___reraise_excs_with_extra_context_gen___close(PyObje
     char cpy_r_r14;
     PyObject *cpy_r_r15;
     cpy_r_r0 = CPyModule_builtins;
-    cpy_r_r1 = CPyStatics[145]; /* 'GeneratorExit' */
+    cpy_r_r1 = CPyStatics[147]; /* 'GeneratorExit' */
     cpy_r_r2 = CPyObject_GetAttr(cpy_r_r0, cpy_r_r1);
     if (cpy_r_r2 == NULL) goto CPyL3;
     cpy_r_r3 = (PyObject *)&_Py_NoneStruct;
@@ -12260,7 +12369,7 @@ PyObject *CPyDef_exceptions___reraise_excs_with_extra_context_gen___close(PyObje
 CPyL3: ;
     cpy_r_r6 = CPy_CatchError();
     cpy_r_r7 = CPyModule_builtins;
-    cpy_r_r8 = CPyStatics[146]; /* 'StopIteration' */
+    cpy_r_r8 = CPyStatics[148]; /* 'StopIteration' */
     cpy_r_r9 = CPyObject_GetAttr(cpy_r_r7, cpy_r_r8);
     if (cpy_r_r9 == NULL) goto CPyL12;
     cpy_r_r10.f0 = cpy_r_r2;
@@ -12807,14 +12916,14 @@ CPyL3: ;
     cpy_r_r7 = (void *)&cpy_r_r6;
     int64_t cpy_r_r8[1] = {1};
     cpy_r_r9 = (void *)&cpy_r_r8;
-    cpy_r_r10 = CPyStatics[523]; /* (('logging', 'logging', 'logging'),) */
+    cpy_r_r10 = CPyStatics[524]; /* (('logging', 'logging', 'logging'),) */
     cpy_r_r11 = CPyStatic_exceptions___globals;
-    cpy_r_r12 = CPyStatics[205]; /* 'y/exceptions.py' */
+    cpy_r_r12 = CPyStatics[207]; /* 'y/exceptions.py' */
     cpy_r_r13 = CPyStatics[31]; /* '<module>' */
     cpy_r_r14 = CPyImport_ImportMany(cpy_r_r10, cpy_r_r7, cpy_r_r11, cpy_r_r12, cpy_r_r13, cpy_r_r9);
     if (!cpy_r_r14) goto CPyL129;
-    cpy_r_r15 = CPyStatics[524]; /* ('contextmanager',) */
-    cpy_r_r16 = CPyStatics[207]; /* 'contextlib' */
+    cpy_r_r15 = CPyStatics[525]; /* ('contextmanager',) */
+    cpy_r_r16 = CPyStatics[209]; /* 'contextlib' */
     cpy_r_r17 = CPyStatic_exceptions___globals;
     cpy_r_r18 = CPyImport_ImportFromMany(cpy_r_r16, cpy_r_r15, cpy_r_r15, cpy_r_r17);
     if (unlikely(cpy_r_r18 == NULL)) {
@@ -12824,7 +12933,7 @@ CPyL3: ;
     CPyModule_contextlib = cpy_r_r18;
     CPy_INCREF(CPyModule_contextlib);
     CPy_DECREF(cpy_r_r18);
-    cpy_r_r19 = CPyStatics[525]; /* ('TYPE_CHECKING', 'Any', 'Final', 'Optional', 'final') */
+    cpy_r_r19 = CPyStatics[526]; /* ('TYPE_CHECKING', 'Any', 'Final', 'Optional', 'final') */
     cpy_r_r20 = CPyStatics[37]; /* 'typing' */
     cpy_r_r21 = CPyStatic_exceptions___globals;
     cpy_r_r22 = CPyImport_ImportFromMany(cpy_r_r20, cpy_r_r19, cpy_r_r19, cpy_r_r21);
@@ -12835,8 +12944,8 @@ CPyL3: ;
     CPyModule_typing = cpy_r_r22;
     CPy_INCREF(CPyModule_typing);
     CPy_DECREF(cpy_r_r22);
-    cpy_r_r23 = CPyStatics[526]; /* ('Contract',) */
-    cpy_r_r24 = CPyStatics[527]; /* ('BrownieContract',) */
+    cpy_r_r23 = CPyStatics[527]; /* ('Contract',) */
+    cpy_r_r24 = CPyStatics[528]; /* ('BrownieContract',) */
     cpy_r_r25 = CPyStatics[44]; /* 'brownie' */
     cpy_r_r26 = CPyStatic_exceptions___globals;
     cpy_r_r27 = CPyImport_ImportFromMany(cpy_r_r25, cpy_r_r23, cpy_r_r24, cpy_r_r26);
@@ -12847,8 +12956,8 @@ CPyL3: ;
     CPyModule_brownie = cpy_r_r27;
     CPy_INCREF(CPyModule_brownie);
     CPy_DECREF(cpy_r_r27);
-    cpy_r_r28 = CPyStatics[528]; /* ('CompilerError',) */
-    cpy_r_r29 = CPyStatics[211]; /* 'brownie.exceptions' */
+    cpy_r_r28 = CPyStatics[529]; /* ('CompilerError',) */
+    cpy_r_r29 = CPyStatics[213]; /* 'brownie.exceptions' */
     cpy_r_r30 = CPyStatic_exceptions___globals;
     cpy_r_r31 = CPyImport_ImportFromMany(cpy_r_r29, cpy_r_r28, cpy_r_r28, cpy_r_r30);
     if (unlikely(cpy_r_r31 == NULL)) {
@@ -12858,8 +12967,8 @@ CPyL3: ;
     CPyModule_brownie___exceptions = cpy_r_r31;
     CPy_INCREF(CPyModule_brownie___exceptions);
     CPy_DECREF(cpy_r_r31);
-    cpy_r_r32 = CPyStatics[529]; /* ('BlockNumber', 'ChecksumAddress') */
-    cpy_r_r33 = CPyStatics[159]; /* 'eth_typing' */
+    cpy_r_r32 = CPyStatics[530]; /* ('BlockNumber', 'ChecksumAddress') */
+    cpy_r_r33 = CPyStatics[161]; /* 'eth_typing' */
     cpy_r_r34 = CPyStatic_exceptions___globals;
     cpy_r_r35 = CPyImport_ImportFromMany(cpy_r_r33, cpy_r_r32, cpy_r_r32, cpy_r_r34);
     if (unlikely(cpy_r_r35 == NULL)) {
@@ -12869,8 +12978,8 @@ CPyL3: ;
     CPyModule_eth_typing = cpy_r_r35;
     CPy_INCREF(CPyModule_eth_typing);
     CPy_DECREF(cpy_r_r35);
-    cpy_r_r36 = CPyStatics[530]; /* ('ContractLogicError',) */
-    cpy_r_r37 = CPyStatics[213]; /* 'web3.exceptions' */
+    cpy_r_r36 = CPyStatics[531]; /* ('ContractLogicError',) */
+    cpy_r_r37 = CPyStatics[215]; /* 'web3.exceptions' */
     cpy_r_r38 = CPyStatic_exceptions___globals;
     cpy_r_r39 = CPyImport_ImportFromMany(cpy_r_r37, cpy_r_r36, cpy_r_r36, cpy_r_r38);
     if (unlikely(cpy_r_r39 == NULL)) {
@@ -12880,8 +12989,8 @@ CPyL3: ;
     CPyModule_web3___exceptions = cpy_r_r39;
     CPy_INCREF(CPyModule_web3___exceptions);
     CPy_DECREF(cpy_r_r39);
-    cpy_r_r40 = CPyStatics[520]; /* ('AnyAddressType',) */
-    cpy_r_r41 = CPyStatics[161]; /* 'y.datatypes' */
+    cpy_r_r40 = CPyStatics[521]; /* ('AnyAddressType',) */
+    cpy_r_r41 = CPyStatics[163]; /* 'y.datatypes' */
     cpy_r_r42 = CPyStatic_exceptions___globals;
     cpy_r_r43 = CPyImport_ImportFromMany(cpy_r_r41, cpy_r_r40, cpy_r_r40, cpy_r_r42);
     if (unlikely(cpy_r_r43 == NULL)) {
@@ -12905,7 +13014,7 @@ CPyL3: ;
         goto CPyL129;
     }
     cpy_r_r48 = CPyModule_logging;
-    cpy_r_r49 = CPyStatics[49]; /* 'getLogger' */
+    cpy_r_r49 = CPyStatics[52]; /* 'getLogger' */
     cpy_r_r50 = CPyObject_GetAttr(cpy_r_r48, cpy_r_r49);
     if (unlikely(cpy_r_r50 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "<module>", 16, CPyStatic_exceptions___globals);
@@ -12923,7 +13032,7 @@ CPyL3: ;
     CPyStatic_exceptions___logger = cpy_r_r53;
     CPy_INCREF(CPyStatic_exceptions___logger);
     cpy_r_r54 = CPyStatic_exceptions___globals;
-    cpy_r_r55 = CPyStatics[50]; /* 'logger' */
+    cpy_r_r55 = CPyStatics[53]; /* 'logger' */
     cpy_r_r56 = CPyDict_SetItem(cpy_r_r54, cpy_r_r55, cpy_r_r53);
     CPy_DECREF(cpy_r_r53);
     cpy_r_r57 = cpy_r_r56 >= 0;
@@ -12932,7 +13041,7 @@ CPyL3: ;
         goto CPyL129;
     }
     cpy_r_r58 = CPyModule_builtins;
-    cpy_r_r59 = CPyStatics[141]; /* 'ValueError' */
+    cpy_r_r59 = CPyStatics[143]; /* 'ValueError' */
     cpy_r_r60 = CPyObject_GetAttr(cpy_r_r58, cpy_r_r59);
     if (unlikely(cpy_r_r60 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "<module>", 22, CPyStatic_exceptions___globals);
@@ -12944,7 +13053,7 @@ CPyL3: ;
         CPy_AddTraceback("y/exceptions.py", "<module>", 22, CPyStatic_exceptions___globals);
         goto CPyL129;
     }
-    cpy_r_r62 = CPyStatics[214]; /* 'y.exceptions' */
+    cpy_r_r62 = CPyStatics[216]; /* 'y.exceptions' */
     cpy_r_r63 = (PyObject *)CPyType_exceptions___yPriceMagicError_template;
     cpy_r_r64 = CPyType_FromTemplate(cpy_r_r63, cpy_r_r61, cpy_r_r62);
     CPy_DECREF(cpy_r_r61);
@@ -12952,8 +13061,8 @@ CPyL3: ;
         CPy_AddTraceback("y/exceptions.py", "<module>", 22, CPyStatic_exceptions___globals);
         goto CPyL129;
     }
-    cpy_r_r65 = CPyStatics[215]; /* '__mypyc_attrs__' */
-    cpy_r_r66 = CPyStatics[216]; /* '__dict__' */
+    cpy_r_r65 = CPyStatics[217]; /* '__mypyc_attrs__' */
+    cpy_r_r66 = CPyStatics[218]; /* '__dict__' */
     cpy_r_r67 = PyTuple_Pack(1, cpy_r_r66);
     if (unlikely(cpy_r_r67 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "<module>", 22, CPyStatic_exceptions___globals);
@@ -12969,7 +13078,7 @@ CPyL3: ;
     CPyType_exceptions___yPriceMagicError = (PyTypeObject *)cpy_r_r64;
     CPy_INCREF(CPyType_exceptions___yPriceMagicError);
     cpy_r_r70 = CPyStatic_exceptions___globals;
-    cpy_r_r71 = CPyStatics[217]; /* 'yPriceMagicError' */
+    cpy_r_r71 = CPyStatics[219]; /* 'yPriceMagicError' */
     cpy_r_r72 = CPyDict_SetItem(cpy_r_r70, cpy_r_r71, cpy_r_r64);
     CPy_DECREF(cpy_r_r64);
     cpy_r_r73 = cpy_r_r72 >= 0;
@@ -12978,7 +13087,7 @@ CPyL3: ;
         goto CPyL129;
     }
     cpy_r_r74 = CPyModule_builtins;
-    cpy_r_r75 = CPyStatics[184]; /* 'Exception' */
+    cpy_r_r75 = CPyStatics[186]; /* 'Exception' */
     cpy_r_r76 = CPyObject_GetAttr(cpy_r_r74, cpy_r_r75);
     if (unlikely(cpy_r_r76 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "<module>", 65, CPyStatic_exceptions___globals);
@@ -12990,7 +13099,7 @@ CPyL3: ;
         CPy_AddTraceback("y/exceptions.py", "<module>", 65, CPyStatic_exceptions___globals);
         goto CPyL129;
     }
-    cpy_r_r78 = CPyStatics[214]; /* 'y.exceptions' */
+    cpy_r_r78 = CPyStatics[216]; /* 'y.exceptions' */
     cpy_r_r79 = (PyObject *)CPyType_exceptions___PriceError_template;
     cpy_r_r80 = CPyType_FromTemplate(cpy_r_r79, cpy_r_r77, cpy_r_r78);
     CPy_DECREF(cpy_r_r77);
@@ -12998,8 +13107,8 @@ CPyL3: ;
         CPy_AddTraceback("y/exceptions.py", "<module>", 65, CPyStatic_exceptions___globals);
         goto CPyL129;
     }
-    cpy_r_r81 = CPyStatics[215]; /* '__mypyc_attrs__' */
-    cpy_r_r82 = CPyStatics[216]; /* '__dict__' */
+    cpy_r_r81 = CPyStatics[217]; /* '__mypyc_attrs__' */
+    cpy_r_r82 = CPyStatics[218]; /* '__dict__' */
     cpy_r_r83 = PyTuple_Pack(1, cpy_r_r82);
     if (unlikely(cpy_r_r83 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "<module>", 65, CPyStatic_exceptions___globals);
@@ -13015,7 +13124,7 @@ CPyL3: ;
     CPyType_exceptions___PriceError = (PyTypeObject *)cpy_r_r80;
     CPy_INCREF(CPyType_exceptions___PriceError);
     cpy_r_r86 = CPyStatic_exceptions___globals;
-    cpy_r_r87 = CPyStatics[218]; /* 'PriceError' */
+    cpy_r_r87 = CPyStatics[220]; /* 'PriceError' */
     cpy_r_r88 = CPyDict_SetItem(cpy_r_r86, cpy_r_r87, cpy_r_r80);
     CPy_DECREF(cpy_r_r80);
     cpy_r_r89 = cpy_r_r88 >= 0;
@@ -13024,7 +13133,7 @@ CPyL3: ;
         goto CPyL129;
     }
     cpy_r_r90 = CPyModule_builtins;
-    cpy_r_r91 = CPyStatics[141]; /* 'ValueError' */
+    cpy_r_r91 = CPyStatics[143]; /* 'ValueError' */
     cpy_r_r92 = CPyObject_GetAttr(cpy_r_r90, cpy_r_r91);
     if (unlikely(cpy_r_r92 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "<module>", 75, CPyStatic_exceptions___globals);
@@ -13036,7 +13145,7 @@ CPyL3: ;
         CPy_AddTraceback("y/exceptions.py", "<module>", 75, CPyStatic_exceptions___globals);
         goto CPyL129;
     }
-    cpy_r_r94 = CPyStatics[214]; /* 'y.exceptions' */
+    cpy_r_r94 = CPyStatics[216]; /* 'y.exceptions' */
     cpy_r_r95 = (PyObject *)CPyType_exceptions___UnsupportedNetwork_template;
     cpy_r_r96 = CPyType_FromTemplate(cpy_r_r95, cpy_r_r93, cpy_r_r94);
     CPy_DECREF(cpy_r_r93);
@@ -13044,8 +13153,8 @@ CPyL3: ;
         CPy_AddTraceback("y/exceptions.py", "<module>", 75, CPyStatic_exceptions___globals);
         goto CPyL129;
     }
-    cpy_r_r97 = CPyStatics[215]; /* '__mypyc_attrs__' */
-    cpy_r_r98 = CPyStatics[216]; /* '__dict__' */
+    cpy_r_r97 = CPyStatics[217]; /* '__mypyc_attrs__' */
+    cpy_r_r98 = CPyStatics[218]; /* '__dict__' */
     cpy_r_r99 = PyTuple_Pack(1, cpy_r_r98);
     if (unlikely(cpy_r_r99 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "<module>", 75, CPyStatic_exceptions___globals);
@@ -13061,7 +13170,7 @@ CPyL3: ;
     CPyType_exceptions___UnsupportedNetwork = (PyTypeObject *)cpy_r_r96;
     CPy_INCREF(CPyType_exceptions___UnsupportedNetwork);
     cpy_r_r102 = CPyStatic_exceptions___globals;
-    cpy_r_r103 = CPyStatics[219]; /* 'UnsupportedNetwork' */
+    cpy_r_r103 = CPyStatics[221]; /* 'UnsupportedNetwork' */
     cpy_r_r104 = CPyDict_SetItem(cpy_r_r102, cpy_r_r103, cpy_r_r96);
     CPy_DECREF(cpy_r_r96);
     cpy_r_r105 = cpy_r_r104 >= 0;
@@ -13070,7 +13179,7 @@ CPyL3: ;
         goto CPyL129;
     }
     cpy_r_r106 = CPyModule_builtins;
-    cpy_r_r107 = CPyStatics[184]; /* 'Exception' */
+    cpy_r_r107 = CPyStatics[186]; /* 'Exception' */
     cpy_r_r108 = CPyObject_GetAttr(cpy_r_r106, cpy_r_r107);
     if (unlikely(cpy_r_r108 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "<module>", 82, CPyStatic_exceptions___globals);
@@ -13082,7 +13191,7 @@ CPyL3: ;
         CPy_AddTraceback("y/exceptions.py", "<module>", 82, CPyStatic_exceptions___globals);
         goto CPyL129;
     }
-    cpy_r_r110 = CPyStatics[214]; /* 'y.exceptions' */
+    cpy_r_r110 = CPyStatics[216]; /* 'y.exceptions' */
     cpy_r_r111 = (PyObject *)CPyType_exceptions___NonStandardERC20_template;
     cpy_r_r112 = CPyType_FromTemplate(cpy_r_r111, cpy_r_r109, cpy_r_r110);
     CPy_DECREF(cpy_r_r109);
@@ -13090,8 +13199,8 @@ CPyL3: ;
         CPy_AddTraceback("y/exceptions.py", "<module>", 82, CPyStatic_exceptions___globals);
         goto CPyL129;
     }
-    cpy_r_r113 = CPyStatics[215]; /* '__mypyc_attrs__' */
-    cpy_r_r114 = CPyStatics[216]; /* '__dict__' */
+    cpy_r_r113 = CPyStatics[217]; /* '__mypyc_attrs__' */
+    cpy_r_r114 = CPyStatics[218]; /* '__dict__' */
     cpy_r_r115 = PyTuple_Pack(1, cpy_r_r114);
     if (unlikely(cpy_r_r115 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "<module>", 82, CPyStatic_exceptions___globals);
@@ -13107,7 +13216,7 @@ CPyL3: ;
     CPyType_exceptions___NonStandardERC20 = (PyTypeObject *)cpy_r_r112;
     CPy_INCREF(CPyType_exceptions___NonStandardERC20);
     cpy_r_r118 = CPyStatic_exceptions___globals;
-    cpy_r_r119 = CPyStatics[220]; /* 'NonStandardERC20' */
+    cpy_r_r119 = CPyStatics[222]; /* 'NonStandardERC20' */
     cpy_r_r120 = CPyDict_SetItem(cpy_r_r118, cpy_r_r119, cpy_r_r112);
     CPy_DECREF(cpy_r_r112);
     cpy_r_r121 = cpy_r_r120 >= 0;
@@ -13116,7 +13225,7 @@ CPyL3: ;
         goto CPyL129;
     }
     cpy_r_r122 = CPyModule_builtins;
-    cpy_r_r123 = CPyStatics[184]; /* 'Exception' */
+    cpy_r_r123 = CPyStatics[186]; /* 'Exception' */
     cpy_r_r124 = CPyObject_GetAttr(cpy_r_r122, cpy_r_r123);
     if (unlikely(cpy_r_r124 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "<module>", 89, CPyStatic_exceptions___globals);
@@ -13128,7 +13237,7 @@ CPyL3: ;
         CPy_AddTraceback("y/exceptions.py", "<module>", 89, CPyStatic_exceptions___globals);
         goto CPyL129;
     }
-    cpy_r_r126 = CPyStatics[214]; /* 'y.exceptions' */
+    cpy_r_r126 = CPyStatics[216]; /* 'y.exceptions' */
     cpy_r_r127 = (PyObject *)CPyType_exceptions___CantFetchParam_template;
     cpy_r_r128 = CPyType_FromTemplate(cpy_r_r127, cpy_r_r125, cpy_r_r126);
     CPy_DECREF(cpy_r_r125);
@@ -13136,8 +13245,8 @@ CPyL3: ;
         CPy_AddTraceback("y/exceptions.py", "<module>", 89, CPyStatic_exceptions___globals);
         goto CPyL129;
     }
-    cpy_r_r129 = CPyStatics[215]; /* '__mypyc_attrs__' */
-    cpy_r_r130 = CPyStatics[216]; /* '__dict__' */
+    cpy_r_r129 = CPyStatics[217]; /* '__mypyc_attrs__' */
+    cpy_r_r130 = CPyStatics[218]; /* '__dict__' */
     cpy_r_r131 = PyTuple_Pack(1, cpy_r_r130);
     if (unlikely(cpy_r_r131 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "<module>", 89, CPyStatic_exceptions___globals);
@@ -13153,7 +13262,7 @@ CPyL3: ;
     CPyType_exceptions___CantFetchParam = (PyTypeObject *)cpy_r_r128;
     CPy_INCREF(CPyType_exceptions___CantFetchParam);
     cpy_r_r134 = CPyStatic_exceptions___globals;
-    cpy_r_r135 = CPyStatics[221]; /* 'CantFetchParam' */
+    cpy_r_r135 = CPyStatics[223]; /* 'CantFetchParam' */
     cpy_r_r136 = CPyDict_SetItem(cpy_r_r134, cpy_r_r135, cpy_r_r128);
     CPy_DECREF(cpy_r_r128);
     cpy_r_r137 = cpy_r_r136 >= 0;
@@ -13162,7 +13271,7 @@ CPyL3: ;
         goto CPyL129;
     }
     cpy_r_r138 = CPyModule_builtins;
-    cpy_r_r139 = CPyStatics[141]; /* 'ValueError' */
+    cpy_r_r139 = CPyStatics[143]; /* 'ValueError' */
     cpy_r_r140 = CPyObject_GetAttr(cpy_r_r138, cpy_r_r139);
     if (unlikely(cpy_r_r140 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "<module>", 94, CPyStatic_exceptions___globals);
@@ -13174,7 +13283,7 @@ CPyL3: ;
         CPy_AddTraceback("y/exceptions.py", "<module>", 94, CPyStatic_exceptions___globals);
         goto CPyL129;
     }
-    cpy_r_r142 = CPyStatics[214]; /* 'y.exceptions' */
+    cpy_r_r142 = CPyStatics[216]; /* 'y.exceptions' */
     cpy_r_r143 = (PyObject *)CPyType_exceptions___TokenError_template;
     cpy_r_r144 = CPyType_FromTemplate(cpy_r_r143, cpy_r_r141, cpy_r_r142);
     CPy_DECREF(cpy_r_r141);
@@ -13182,8 +13291,8 @@ CPyL3: ;
         CPy_AddTraceback("y/exceptions.py", "<module>", 94, CPyStatic_exceptions___globals);
         goto CPyL129;
     }
-    cpy_r_r145 = CPyStatics[215]; /* '__mypyc_attrs__' */
-    cpy_r_r146 = CPyStatics[216]; /* '__dict__' */
+    cpy_r_r145 = CPyStatics[217]; /* '__mypyc_attrs__' */
+    cpy_r_r146 = CPyStatics[218]; /* '__dict__' */
     cpy_r_r147 = PyTuple_Pack(1, cpy_r_r146);
     if (unlikely(cpy_r_r147 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "<module>", 94, CPyStatic_exceptions___globals);
@@ -13199,7 +13308,7 @@ CPyL3: ;
     CPyType_exceptions___TokenError = (PyTypeObject *)cpy_r_r144;
     CPy_INCREF(CPyType_exceptions___TokenError);
     cpy_r_r150 = CPyStatic_exceptions___globals;
-    cpy_r_r151 = CPyStatics[222]; /* 'TokenError' */
+    cpy_r_r151 = CPyStatics[224]; /* 'TokenError' */
     cpy_r_r152 = CPyDict_SetItem(cpy_r_r150, cpy_r_r151, cpy_r_r144);
     CPy_DECREF(cpy_r_r144);
     cpy_r_r153 = cpy_r_r152 >= 0;
@@ -13208,7 +13317,7 @@ CPyL3: ;
         goto CPyL129;
     }
     cpy_r_r154 = CPyModule_builtins;
-    cpy_r_r155 = CPyStatics[184]; /* 'Exception' */
+    cpy_r_r155 = CPyStatics[186]; /* 'Exception' */
     cpy_r_r156 = CPyObject_GetAttr(cpy_r_r154, cpy_r_r155);
     if (unlikely(cpy_r_r156 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "<module>", 104, CPyStatic_exceptions___globals);
@@ -13220,7 +13329,7 @@ CPyL3: ;
         CPy_AddTraceback("y/exceptions.py", "<module>", 104, CPyStatic_exceptions___globals);
         goto CPyL129;
     }
-    cpy_r_r158 = CPyStatics[214]; /* 'y.exceptions' */
+    cpy_r_r158 = CPyStatics[216]; /* 'y.exceptions' */
     cpy_r_r159 = (PyObject *)CPyType_exceptions____ExplorerError_template;
     cpy_r_r160 = CPyType_FromTemplate(cpy_r_r159, cpy_r_r157, cpy_r_r158);
     CPy_DECREF(cpy_r_r157);
@@ -13228,8 +13337,8 @@ CPyL3: ;
         CPy_AddTraceback("y/exceptions.py", "<module>", 104, CPyStatic_exceptions___globals);
         goto CPyL129;
     }
-    cpy_r_r161 = CPyStatics[215]; /* '__mypyc_attrs__' */
-    cpy_r_r162 = CPyStatics[216]; /* '__dict__' */
+    cpy_r_r161 = CPyStatics[217]; /* '__mypyc_attrs__' */
+    cpy_r_r162 = CPyStatics[218]; /* '__dict__' */
     cpy_r_r163 = PyTuple_Pack(1, cpy_r_r162);
     if (unlikely(cpy_r_r163 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "<module>", 104, CPyStatic_exceptions___globals);
@@ -13245,7 +13354,7 @@ CPyL3: ;
     CPyType_exceptions____ExplorerError = (PyTypeObject *)cpy_r_r160;
     CPy_INCREF(CPyType_exceptions____ExplorerError);
     cpy_r_r166 = CPyStatic_exceptions___globals;
-    cpy_r_r167 = CPyStatics[223]; /* '_ExplorerError' */
+    cpy_r_r167 = CPyStatics[225]; /* '_ExplorerError' */
     cpy_r_r168 = CPyDict_SetItem(cpy_r_r166, cpy_r_r167, cpy_r_r160);
     CPy_DECREF(cpy_r_r160);
     cpy_r_r169 = cpy_r_r168 >= 0;
@@ -13259,7 +13368,7 @@ CPyL3: ;
         CPy_AddTraceback("y/exceptions.py", "<module>", 113, CPyStatic_exceptions___globals);
         goto CPyL129;
     }
-    cpy_r_r172 = CPyStatics[214]; /* 'y.exceptions' */
+    cpy_r_r172 = CPyStatics[216]; /* 'y.exceptions' */
     cpy_r_r173 = (PyObject *)CPyType_exceptions___InvalidAPIKeyError_template;
     cpy_r_r174 = CPyType_FromTemplate(cpy_r_r173, cpy_r_r171, cpy_r_r172);
     CPy_DECREF(cpy_r_r171);
@@ -13267,8 +13376,8 @@ CPyL3: ;
         CPy_AddTraceback("y/exceptions.py", "<module>", 113, CPyStatic_exceptions___globals);
         goto CPyL129;
     }
-    cpy_r_r175 = CPyStatics[215]; /* '__mypyc_attrs__' */
-    cpy_r_r176 = CPyStatics[216]; /* '__dict__' */
+    cpy_r_r175 = CPyStatics[217]; /* '__mypyc_attrs__' */
+    cpy_r_r176 = CPyStatics[218]; /* '__dict__' */
     cpy_r_r177 = PyTuple_Pack(1, cpy_r_r176);
     if (unlikely(cpy_r_r177 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "<module>", 113, CPyStatic_exceptions___globals);
@@ -13284,7 +13393,7 @@ CPyL3: ;
     CPyType_exceptions___InvalidAPIKeyError = (PyTypeObject *)cpy_r_r174;
     CPy_INCREF(CPyType_exceptions___InvalidAPIKeyError);
     cpy_r_r180 = CPyStatic_exceptions___globals;
-    cpy_r_r181 = CPyStatics[224]; /* 'InvalidAPIKeyError' */
+    cpy_r_r181 = CPyStatics[226]; /* 'InvalidAPIKeyError' */
     cpy_r_r182 = CPyDict_SetItem(cpy_r_r180, cpy_r_r181, cpy_r_r174);
     CPy_DECREF(cpy_r_r174);
     cpy_r_r183 = cpy_r_r182 >= 0;
@@ -13293,9 +13402,9 @@ CPyL3: ;
         goto CPyL129;
     }
     cpy_r_r184 = (PyObject *)CPyType_exceptions___InvalidAPIKeyError;
-    cpy_r_r185 = CPyStatics[225]; /* ('The block explorer for this network says your API key '
+    cpy_r_r185 = CPyStatics[227]; /* ('The block explorer for this network says your API key '
                                      'is invalid.') */
-    cpy_r_r186 = CPyStatics[180]; /* '_msg' */
+    cpy_r_r186 = CPyStatics[182]; /* '_msg' */
     cpy_r_r187 = PyObject_SetAttr(cpy_r_r184, cpy_r_r186, cpy_r_r185);
     cpy_r_r188 = cpy_r_r187 >= 0;
     if (unlikely(!cpy_r_r188)) {
@@ -13308,7 +13417,7 @@ CPyL3: ;
         CPy_AddTraceback("y/exceptions.py", "<module>", 129, CPyStatic_exceptions___globals);
         goto CPyL129;
     }
-    cpy_r_r191 = CPyStatics[214]; /* 'y.exceptions' */
+    cpy_r_r191 = CPyStatics[216]; /* 'y.exceptions' */
     cpy_r_r192 = (PyObject *)CPyType_exceptions___ContractNotVerified_template;
     cpy_r_r193 = CPyType_FromTemplate(cpy_r_r192, cpy_r_r190, cpy_r_r191);
     CPy_DECREF(cpy_r_r190);
@@ -13316,8 +13425,8 @@ CPyL3: ;
         CPy_AddTraceback("y/exceptions.py", "<module>", 129, CPyStatic_exceptions___globals);
         goto CPyL129;
     }
-    cpy_r_r194 = CPyStatics[215]; /* '__mypyc_attrs__' */
-    cpy_r_r195 = CPyStatics[216]; /* '__dict__' */
+    cpy_r_r194 = CPyStatics[217]; /* '__mypyc_attrs__' */
+    cpy_r_r195 = CPyStatics[218]; /* '__dict__' */
     cpy_r_r196 = PyTuple_Pack(1, cpy_r_r195);
     if (unlikely(cpy_r_r196 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "<module>", 129, CPyStatic_exceptions___globals);
@@ -13333,7 +13442,7 @@ CPyL3: ;
     CPyType_exceptions___ContractNotVerified = (PyTypeObject *)cpy_r_r193;
     CPy_INCREF(CPyType_exceptions___ContractNotVerified);
     cpy_r_r199 = CPyStatic_exceptions___globals;
-    cpy_r_r200 = CPyStatics[226]; /* 'ContractNotVerified' */
+    cpy_r_r200 = CPyStatics[228]; /* 'ContractNotVerified' */
     cpy_r_r201 = CPyDict_SetItem(cpy_r_r199, cpy_r_r200, cpy_r_r193);
     CPy_DECREF(cpy_r_r193);
     cpy_r_r202 = cpy_r_r201 >= 0;
@@ -13342,7 +13451,7 @@ CPyL3: ;
         goto CPyL129;
     }
     cpy_r_r203 = CPyModule_builtins;
-    cpy_r_r204 = CPyStatics[184]; /* 'Exception' */
+    cpy_r_r204 = CPyStatics[186]; /* 'Exception' */
     cpy_r_r205 = CPyObject_GetAttr(cpy_r_r203, cpy_r_r204);
     if (unlikely(cpy_r_r205 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "<module>", 136, CPyStatic_exceptions___globals);
@@ -13354,7 +13463,7 @@ CPyL3: ;
         CPy_AddTraceback("y/exceptions.py", "<module>", 136, CPyStatic_exceptions___globals);
         goto CPyL129;
     }
-    cpy_r_r207 = CPyStatics[214]; /* 'y.exceptions' */
+    cpy_r_r207 = CPyStatics[216]; /* 'y.exceptions' */
     cpy_r_r208 = (PyObject *)CPyType_exceptions___NoProxyImplementation_template;
     cpy_r_r209 = CPyType_FromTemplate(cpy_r_r208, cpy_r_r206, cpy_r_r207);
     CPy_DECREF(cpy_r_r206);
@@ -13362,8 +13471,8 @@ CPyL3: ;
         CPy_AddTraceback("y/exceptions.py", "<module>", 136, CPyStatic_exceptions___globals);
         goto CPyL129;
     }
-    cpy_r_r210 = CPyStatics[215]; /* '__mypyc_attrs__' */
-    cpy_r_r211 = CPyStatics[216]; /* '__dict__' */
+    cpy_r_r210 = CPyStatics[217]; /* '__mypyc_attrs__' */
+    cpy_r_r211 = CPyStatics[218]; /* '__dict__' */
     cpy_r_r212 = PyTuple_Pack(1, cpy_r_r211);
     if (unlikely(cpy_r_r212 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "<module>", 136, CPyStatic_exceptions___globals);
@@ -13379,7 +13488,7 @@ CPyL3: ;
     CPyType_exceptions___NoProxyImplementation = (PyTypeObject *)cpy_r_r209;
     CPy_INCREF(CPyType_exceptions___NoProxyImplementation);
     cpy_r_r215 = CPyStatic_exceptions___globals;
-    cpy_r_r216 = CPyStatics[227]; /* 'NoProxyImplementation' */
+    cpy_r_r216 = CPyStatics[229]; /* 'NoProxyImplementation' */
     cpy_r_r217 = CPyDict_SetItem(cpy_r_r215, cpy_r_r216, cpy_r_r209);
     CPy_DECREF(cpy_r_r209);
     cpy_r_r218 = cpy_r_r217 >= 0;
@@ -13388,7 +13497,7 @@ CPyL3: ;
         goto CPyL129;
     }
     cpy_r_r219 = CPyModule_builtins;
-    cpy_r_r220 = CPyStatics[184]; /* 'Exception' */
+    cpy_r_r220 = CPyStatics[186]; /* 'Exception' */
     cpy_r_r221 = CPyObject_GetAttr(cpy_r_r219, cpy_r_r220);
     if (unlikely(cpy_r_r221 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "<module>", 145, CPyStatic_exceptions___globals);
@@ -13400,7 +13509,7 @@ CPyL3: ;
         CPy_AddTraceback("y/exceptions.py", "<module>", 145, CPyStatic_exceptions___globals);
         goto CPyL129;
     }
-    cpy_r_r223 = CPyStatics[214]; /* 'y.exceptions' */
+    cpy_r_r223 = CPyStatics[216]; /* 'y.exceptions' */
     cpy_r_r224 = (PyObject *)CPyType_exceptions___MessedUpBrownieContract_template;
     cpy_r_r225 = CPyType_FromTemplate(cpy_r_r224, cpy_r_r222, cpy_r_r223);
     CPy_DECREF(cpy_r_r222);
@@ -13408,8 +13517,8 @@ CPyL3: ;
         CPy_AddTraceback("y/exceptions.py", "<module>", 145, CPyStatic_exceptions___globals);
         goto CPyL129;
     }
-    cpy_r_r226 = CPyStatics[215]; /* '__mypyc_attrs__' */
-    cpy_r_r227 = CPyStatics[216]; /* '__dict__' */
+    cpy_r_r226 = CPyStatics[217]; /* '__mypyc_attrs__' */
+    cpy_r_r227 = CPyStatics[218]; /* '__dict__' */
     cpy_r_r228 = PyTuple_Pack(1, cpy_r_r227);
     if (unlikely(cpy_r_r228 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "<module>", 145, CPyStatic_exceptions___globals);
@@ -13425,7 +13534,7 @@ CPyL3: ;
     CPyType_exceptions___MessedUpBrownieContract = (PyTypeObject *)cpy_r_r225;
     CPy_INCREF(CPyType_exceptions___MessedUpBrownieContract);
     cpy_r_r231 = CPyStatic_exceptions___globals;
-    cpy_r_r232 = CPyStatics[228]; /* 'MessedUpBrownieContract' */
+    cpy_r_r232 = CPyStatics[230]; /* 'MessedUpBrownieContract' */
     cpy_r_r233 = CPyDict_SetItem(cpy_r_r231, cpy_r_r232, cpy_r_r225);
     CPy_DECREF(cpy_r_r225);
     cpy_r_r234 = cpy_r_r233 >= 0;
@@ -13434,7 +13543,7 @@ CPyL3: ;
         goto CPyL129;
     }
     cpy_r_r235 = CPyModule_builtins;
-    cpy_r_r236 = CPyStatics[184]; /* 'Exception' */
+    cpy_r_r236 = CPyStatics[186]; /* 'Exception' */
     cpy_r_r237 = CPyObject_GetAttr(cpy_r_r235, cpy_r_r236);
     if (unlikely(cpy_r_r237 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "<module>", 190, CPyStatic_exceptions___globals);
@@ -13446,7 +13555,7 @@ CPyL3: ;
         CPy_AddTraceback("y/exceptions.py", "<module>", 190, CPyStatic_exceptions___globals);
         goto CPyL129;
     }
-    cpy_r_r239 = CPyStatics[214]; /* 'y.exceptions' */
+    cpy_r_r239 = CPyStatics[216]; /* 'y.exceptions' */
     cpy_r_r240 = (PyObject *)CPyType_exceptions___NotAUniswapV2Pool_template;
     cpy_r_r241 = CPyType_FromTemplate(cpy_r_r240, cpy_r_r238, cpy_r_r239);
     CPy_DECREF(cpy_r_r238);
@@ -13454,8 +13563,8 @@ CPyL3: ;
         CPy_AddTraceback("y/exceptions.py", "<module>", 190, CPyStatic_exceptions___globals);
         goto CPyL129;
     }
-    cpy_r_r242 = CPyStatics[215]; /* '__mypyc_attrs__' */
-    cpy_r_r243 = CPyStatics[216]; /* '__dict__' */
+    cpy_r_r242 = CPyStatics[217]; /* '__mypyc_attrs__' */
+    cpy_r_r243 = CPyStatics[218]; /* '__dict__' */
     cpy_r_r244 = PyTuple_Pack(1, cpy_r_r243);
     if (unlikely(cpy_r_r244 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "<module>", 190, CPyStatic_exceptions___globals);
@@ -13471,7 +13580,7 @@ CPyL3: ;
     CPyType_exceptions___NotAUniswapV2Pool = (PyTypeObject *)cpy_r_r241;
     CPy_INCREF(CPyType_exceptions___NotAUniswapV2Pool);
     cpy_r_r247 = CPyStatic_exceptions___globals;
-    cpy_r_r248 = CPyStatics[229]; /* 'NotAUniswapV2Pool' */
+    cpy_r_r248 = CPyStatics[231]; /* 'NotAUniswapV2Pool' */
     cpy_r_r249 = CPyDict_SetItem(cpy_r_r247, cpy_r_r248, cpy_r_r241);
     CPy_DECREF(cpy_r_r241);
     cpy_r_r250 = cpy_r_r249 >= 0;
@@ -13480,7 +13589,7 @@ CPyL3: ;
         goto CPyL129;
     }
     cpy_r_r251 = CPyModule_builtins;
-    cpy_r_r252 = CPyStatics[184]; /* 'Exception' */
+    cpy_r_r252 = CPyStatics[186]; /* 'Exception' */
     cpy_r_r253 = CPyObject_GetAttr(cpy_r_r251, cpy_r_r252);
     if (unlikely(cpy_r_r253 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "<module>", 206, CPyStatic_exceptions___globals);
@@ -13492,7 +13601,7 @@ CPyL3: ;
         CPy_AddTraceback("y/exceptions.py", "<module>", 206, CPyStatic_exceptions___globals);
         goto CPyL129;
     }
-    cpy_r_r255 = CPyStatics[214]; /* 'y.exceptions' */
+    cpy_r_r255 = CPyStatics[216]; /* 'y.exceptions' */
     cpy_r_r256 = (PyObject *)CPyType_exceptions___NotABalancerV2Pool_template;
     cpy_r_r257 = CPyType_FromTemplate(cpy_r_r256, cpy_r_r254, cpy_r_r255);
     CPy_DECREF(cpy_r_r254);
@@ -13500,8 +13609,8 @@ CPyL3: ;
         CPy_AddTraceback("y/exceptions.py", "<module>", 206, CPyStatic_exceptions___globals);
         goto CPyL129;
     }
-    cpy_r_r258 = CPyStatics[215]; /* '__mypyc_attrs__' */
-    cpy_r_r259 = CPyStatics[216]; /* '__dict__' */
+    cpy_r_r258 = CPyStatics[217]; /* '__mypyc_attrs__' */
+    cpy_r_r259 = CPyStatics[218]; /* '__dict__' */
     cpy_r_r260 = PyTuple_Pack(1, cpy_r_r259);
     if (unlikely(cpy_r_r260 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "<module>", 206, CPyStatic_exceptions___globals);
@@ -13517,7 +13626,7 @@ CPyL3: ;
     CPyType_exceptions___NotABalancerV2Pool = (PyTypeObject *)cpy_r_r257;
     CPy_INCREF(CPyType_exceptions___NotABalancerV2Pool);
     cpy_r_r263 = CPyStatic_exceptions___globals;
-    cpy_r_r264 = CPyStatics[230]; /* 'NotABalancerV2Pool' */
+    cpy_r_r264 = CPyStatics[232]; /* 'NotABalancerV2Pool' */
     cpy_r_r265 = CPyDict_SetItem(cpy_r_r263, cpy_r_r264, cpy_r_r257);
     CPy_DECREF(cpy_r_r257);
     cpy_r_r266 = cpy_r_r265 >= 0;
@@ -13526,7 +13635,7 @@ CPyL3: ;
         goto CPyL129;
     }
     cpy_r_r267 = CPyModule_builtins;
-    cpy_r_r268 = CPyStatics[184]; /* 'Exception' */
+    cpy_r_r268 = CPyStatics[186]; /* 'Exception' */
     cpy_r_r269 = CPyObject_GetAttr(cpy_r_r267, cpy_r_r268);
     if (unlikely(cpy_r_r269 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "<module>", 216, CPyStatic_exceptions___globals);
@@ -13538,7 +13647,7 @@ CPyL3: ;
         CPy_AddTraceback("y/exceptions.py", "<module>", 216, CPyStatic_exceptions___globals);
         goto CPyL129;
     }
-    cpy_r_r271 = CPyStatics[214]; /* 'y.exceptions' */
+    cpy_r_r271 = CPyStatics[216]; /* 'y.exceptions' */
     cpy_r_r272 = (PyObject *)CPyType_exceptions___CantFindSwapPath_template;
     cpy_r_r273 = CPyType_FromTemplate(cpy_r_r272, cpy_r_r270, cpy_r_r271);
     CPy_DECREF(cpy_r_r270);
@@ -13546,8 +13655,8 @@ CPyL3: ;
         CPy_AddTraceback("y/exceptions.py", "<module>", 216, CPyStatic_exceptions___globals);
         goto CPyL129;
     }
-    cpy_r_r274 = CPyStatics[215]; /* '__mypyc_attrs__' */
-    cpy_r_r275 = CPyStatics[216]; /* '__dict__' */
+    cpy_r_r274 = CPyStatics[217]; /* '__mypyc_attrs__' */
+    cpy_r_r275 = CPyStatics[218]; /* '__dict__' */
     cpy_r_r276 = PyTuple_Pack(1, cpy_r_r275);
     if (unlikely(cpy_r_r276 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "<module>", 216, CPyStatic_exceptions___globals);
@@ -13563,7 +13672,7 @@ CPyL3: ;
     CPyType_exceptions___CantFindSwapPath = (PyTypeObject *)cpy_r_r273;
     CPy_INCREF(CPyType_exceptions___CantFindSwapPath);
     cpy_r_r279 = CPyStatic_exceptions___globals;
-    cpy_r_r280 = CPyStatics[231]; /* 'CantFindSwapPath' */
+    cpy_r_r280 = CPyStatics[233]; /* 'CantFindSwapPath' */
     cpy_r_r281 = CPyDict_SetItem(cpy_r_r279, cpy_r_r280, cpy_r_r273);
     CPy_DECREF(cpy_r_r273);
     cpy_r_r282 = cpy_r_r281 >= 0;
@@ -13572,7 +13681,7 @@ CPyL3: ;
         goto CPyL129;
     }
     cpy_r_r283 = CPyModule_builtins;
-    cpy_r_r284 = CPyStatics[141]; /* 'ValueError' */
+    cpy_r_r284 = CPyStatics[143]; /* 'ValueError' */
     cpy_r_r285 = CPyObject_GetAttr(cpy_r_r283, cpy_r_r284);
     if (unlikely(cpy_r_r285 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "<module>", 221, CPyStatic_exceptions___globals);
@@ -13584,7 +13693,7 @@ CPyL3: ;
         CPy_AddTraceback("y/exceptions.py", "<module>", 221, CPyStatic_exceptions___globals);
         goto CPyL129;
     }
-    cpy_r_r287 = CPyStatics[214]; /* 'y.exceptions' */
+    cpy_r_r287 = CPyStatics[216]; /* 'y.exceptions' */
     cpy_r_r288 = (PyObject *)CPyType_exceptions___TokenNotFound_template;
     cpy_r_r289 = CPyType_FromTemplate(cpy_r_r288, cpy_r_r286, cpy_r_r287);
     CPy_DECREF(cpy_r_r286);
@@ -13592,8 +13701,8 @@ CPyL3: ;
         CPy_AddTraceback("y/exceptions.py", "<module>", 221, CPyStatic_exceptions___globals);
         goto CPyL129;
     }
-    cpy_r_r290 = CPyStatics[215]; /* '__mypyc_attrs__' */
-    cpy_r_r291 = CPyStatics[216]; /* '__dict__' */
+    cpy_r_r290 = CPyStatics[217]; /* '__mypyc_attrs__' */
+    cpy_r_r291 = CPyStatics[218]; /* '__dict__' */
     cpy_r_r292 = PyTuple_Pack(1, cpy_r_r291);
     if (unlikely(cpy_r_r292 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "<module>", 221, CPyStatic_exceptions___globals);
@@ -13609,7 +13718,7 @@ CPyL3: ;
     CPyType_exceptions___TokenNotFound = (PyTypeObject *)cpy_r_r289;
     CPy_INCREF(CPyType_exceptions___TokenNotFound);
     cpy_r_r295 = CPyStatic_exceptions___globals;
-    cpy_r_r296 = CPyStatics[232]; /* 'TokenNotFound' */
+    cpy_r_r296 = CPyStatics[234]; /* 'TokenNotFound' */
     cpy_r_r297 = CPyDict_SetItem(cpy_r_r295, cpy_r_r296, cpy_r_r289);
     CPy_DECREF(cpy_r_r289);
     cpy_r_r298 = cpy_r_r297 >= 0;
@@ -13618,7 +13727,7 @@ CPyL3: ;
         goto CPyL129;
     }
     cpy_r_r299 = CPyModule_builtins;
-    cpy_r_r300 = CPyStatics[184]; /* 'Exception' */
+    cpy_r_r300 = CPyStatics[186]; /* 'Exception' */
     cpy_r_r301 = CPyObject_GetAttr(cpy_r_r299, cpy_r_r300);
     if (unlikely(cpy_r_r301 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "<module>", 236, CPyStatic_exceptions___globals);
@@ -13630,7 +13739,7 @@ CPyL3: ;
         CPy_AddTraceback("y/exceptions.py", "<module>", 236, CPyStatic_exceptions___globals);
         goto CPyL129;
     }
-    cpy_r_r303 = CPyStatics[214]; /* 'y.exceptions' */
+    cpy_r_r303 = CPyStatics[216]; /* 'y.exceptions' */
     cpy_r_r304 = (PyObject *)CPyType_exceptions___CalldataPreparationError_template;
     cpy_r_r305 = CPyType_FromTemplate(cpy_r_r304, cpy_r_r302, cpy_r_r303);
     CPy_DECREF(cpy_r_r302);
@@ -13638,8 +13747,8 @@ CPyL3: ;
         CPy_AddTraceback("y/exceptions.py", "<module>", 236, CPyStatic_exceptions___globals);
         goto CPyL129;
     }
-    cpy_r_r306 = CPyStatics[215]; /* '__mypyc_attrs__' */
-    cpy_r_r307 = CPyStatics[216]; /* '__dict__' */
+    cpy_r_r306 = CPyStatics[217]; /* '__mypyc_attrs__' */
+    cpy_r_r307 = CPyStatics[218]; /* '__dict__' */
     cpy_r_r308 = PyTuple_Pack(1, cpy_r_r307);
     if (unlikely(cpy_r_r308 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "<module>", 236, CPyStatic_exceptions___globals);
@@ -13655,7 +13764,7 @@ CPyL3: ;
     CPyType_exceptions___CalldataPreparationError = (PyTypeObject *)cpy_r_r305;
     CPy_INCREF(CPyType_exceptions___CalldataPreparationError);
     cpy_r_r311 = CPyStatic_exceptions___globals;
-    cpy_r_r312 = CPyStatics[233]; /* 'CalldataPreparationError' */
+    cpy_r_r312 = CPyStatics[235]; /* 'CalldataPreparationError' */
     cpy_r_r313 = CPyDict_SetItem(cpy_r_r311, cpy_r_r312, cpy_r_r305);
     CPy_DECREF(cpy_r_r305);
     cpy_r_r314 = cpy_r_r313 >= 0;
@@ -13664,7 +13773,7 @@ CPyL3: ;
         goto CPyL129;
     }
     cpy_r_r315 = CPyModule_builtins;
-    cpy_r_r316 = CPyStatics[184]; /* 'Exception' */
+    cpy_r_r316 = CPyStatics[186]; /* 'Exception' */
     cpy_r_r317 = CPyObject_GetAttr(cpy_r_r315, cpy_r_r316);
     if (unlikely(cpy_r_r317 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "<module>", 243, CPyStatic_exceptions___globals);
@@ -13676,7 +13785,7 @@ CPyL3: ;
         CPy_AddTraceback("y/exceptions.py", "<module>", 243, CPyStatic_exceptions___globals);
         goto CPyL129;
     }
-    cpy_r_r319 = CPyStatics[214]; /* 'y.exceptions' */
+    cpy_r_r319 = CPyStatics[216]; /* 'y.exceptions' */
     cpy_r_r320 = (PyObject *)CPyType_exceptions___CallReverted_template;
     cpy_r_r321 = CPyType_FromTemplate(cpy_r_r320, cpy_r_r318, cpy_r_r319);
     CPy_DECREF(cpy_r_r318);
@@ -13684,8 +13793,8 @@ CPyL3: ;
         CPy_AddTraceback("y/exceptions.py", "<module>", 243, CPyStatic_exceptions___globals);
         goto CPyL129;
     }
-    cpy_r_r322 = CPyStatics[215]; /* '__mypyc_attrs__' */
-    cpy_r_r323 = CPyStatics[216]; /* '__dict__' */
+    cpy_r_r322 = CPyStatics[217]; /* '__mypyc_attrs__' */
+    cpy_r_r323 = CPyStatics[218]; /* '__dict__' */
     cpy_r_r324 = PyTuple_Pack(1, cpy_r_r323);
     if (unlikely(cpy_r_r324 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "<module>", 243, CPyStatic_exceptions___globals);
@@ -13701,7 +13810,7 @@ CPyL3: ;
     CPyType_exceptions___CallReverted = (PyTypeObject *)cpy_r_r321;
     CPy_INCREF(CPyType_exceptions___CallReverted);
     cpy_r_r327 = CPyStatic_exceptions___globals;
-    cpy_r_r328 = CPyStatics[234]; /* 'CallReverted' */
+    cpy_r_r328 = CPyStatics[236]; /* 'CallReverted' */
     cpy_r_r329 = CPyDict_SetItem(cpy_r_r327, cpy_r_r328, cpy_r_r321);
     CPy_DECREF(cpy_r_r321);
     cpy_r_r330 = cpy_r_r329 >= 0;
@@ -13710,7 +13819,7 @@ CPyL3: ;
         goto CPyL129;
     }
     cpy_r_r331 = CPyModule_builtins;
-    cpy_r_r332 = CPyStatics[184]; /* 'Exception' */
+    cpy_r_r332 = CPyStatics[186]; /* 'Exception' */
     cpy_r_r333 = CPyObject_GetAttr(cpy_r_r331, cpy_r_r332);
     if (unlikely(cpy_r_r333 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "<module>", 282, CPyStatic_exceptions___globals);
@@ -13722,7 +13831,7 @@ CPyL3: ;
         CPy_AddTraceback("y/exceptions.py", "<module>", 282, CPyStatic_exceptions___globals);
         goto CPyL129;
     }
-    cpy_r_r335 = CPyStatics[214]; /* 'y.exceptions' */
+    cpy_r_r335 = CPyStatics[216]; /* 'y.exceptions' */
     cpy_r_r336 = (PyObject *)CPyType_exceptions___NodeNotSynced_template;
     cpy_r_r337 = CPyType_FromTemplate(cpy_r_r336, cpy_r_r334, cpy_r_r335);
     CPy_DECREF(cpy_r_r334);
@@ -13730,8 +13839,8 @@ CPyL3: ;
         CPy_AddTraceback("y/exceptions.py", "<module>", 282, CPyStatic_exceptions___globals);
         goto CPyL129;
     }
-    cpy_r_r338 = CPyStatics[215]; /* '__mypyc_attrs__' */
-    cpy_r_r339 = CPyStatics[216]; /* '__dict__' */
+    cpy_r_r338 = CPyStatics[217]; /* '__mypyc_attrs__' */
+    cpy_r_r339 = CPyStatics[218]; /* '__dict__' */
     cpy_r_r340 = PyTuple_Pack(1, cpy_r_r339);
     if (unlikely(cpy_r_r340 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "<module>", 282, CPyStatic_exceptions___globals);
@@ -13747,7 +13856,7 @@ CPyL3: ;
     CPyType_exceptions___NodeNotSynced = (PyTypeObject *)cpy_r_r337;
     CPy_INCREF(CPyType_exceptions___NodeNotSynced);
     cpy_r_r343 = CPyStatic_exceptions___globals;
-    cpy_r_r344 = CPyStatics[235]; /* 'NodeNotSynced' */
+    cpy_r_r344 = CPyStatics[237]; /* 'NodeNotSynced' */
     cpy_r_r345 = CPyDict_SetItem(cpy_r_r343, cpy_r_r344, cpy_r_r337);
     CPy_DECREF(cpy_r_r337);
     cpy_r_r346 = cpy_r_r345 >= 0;
@@ -13756,14 +13865,14 @@ CPyL3: ;
         goto CPyL129;
     }
     cpy_r_r347 = CPyStatic_exceptions___globals;
-    cpy_r_r348 = CPyStatics[236]; /* 'reraise_excs_with_extra_context' */
+    cpy_r_r348 = CPyStatics[238]; /* 'reraise_excs_with_extra_context' */
     cpy_r_r349 = CPyDict_GetItem(cpy_r_r347, cpy_r_r348);
     if (unlikely(cpy_r_r349 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "<module>", 286, CPyStatic_exceptions___globals);
         goto CPyL129;
     }
     cpy_r_r350 = CPyStatic_exceptions___globals;
-    cpy_r_r351 = CPyStatics[206]; /* 'contextmanager' */
+    cpy_r_r351 = CPyStatics[208]; /* 'contextmanager' */
     cpy_r_r352 = CPyDict_GetItem(cpy_r_r350, cpy_r_r351);
     if (unlikely(cpy_r_r352 == NULL)) {
         CPy_AddTraceback("y/exceptions.py", "<module>", 286, CPyStatic_exceptions___globals);
@@ -13779,7 +13888,7 @@ CPyL3: ;
     }
     CPy_DECREF(cpy_r_r349);
     cpy_r_r356 = CPyStatic_exceptions___globals;
-    cpy_r_r357 = CPyStatics[236]; /* 'reraise_excs_with_extra_context' */
+    cpy_r_r357 = CPyStatics[238]; /* 'reraise_excs_with_extra_context' */
     cpy_r_r358 = CPyDict_SetItem(cpy_r_r356, cpy_r_r357, cpy_r_r355);
     CPy_DECREF(cpy_r_r355);
     cpy_r_r359 = cpy_r_r358 >= 0;
@@ -14461,7 +14570,7 @@ CPyL11: ;
     } else
         goto CPyL15;
 CPyL14: ;
-    cpy_r_r12 = CPyStatics[237]; /* 'ETH' */
+    cpy_r_r12 = CPyStatics[239]; /* 'ETH' */
     CPy_INCREF(cpy_r_r12);
     return cpy_r_r12;
 CPyL15: ;
@@ -14509,7 +14618,7 @@ CPyL19: ;
     } else
         goto CPyL23;
 CPyL22: ;
-    cpy_r_r19 = CPyStatics[238]; /* 'BSC' */
+    cpy_r_r19 = CPyStatics[240]; /* 'BSC' */
     CPy_INCREF(cpy_r_r19);
     return cpy_r_r19;
 CPyL23: ;
@@ -14557,7 +14666,7 @@ CPyL27: ;
     } else
         goto CPyL31;
 CPyL30: ;
-    cpy_r_r26 = CPyStatics[239]; /* 'GNO' */
+    cpy_r_r26 = CPyStatics[241]; /* 'GNO' */
     CPy_INCREF(cpy_r_r26);
     return cpy_r_r26;
 CPyL31: ;
@@ -14605,7 +14714,7 @@ CPyL35: ;
     } else
         goto CPyL39;
 CPyL38: ;
-    cpy_r_r33 = CPyStatics[240]; /* 'HECO' */
+    cpy_r_r33 = CPyStatics[242]; /* 'HECO' */
     CPy_INCREF(cpy_r_r33);
     return cpy_r_r33;
 CPyL39: ;
@@ -14653,7 +14762,7 @@ CPyL43: ;
     } else
         goto CPyL47;
 CPyL46: ;
-    cpy_r_r40 = CPyStatics[241]; /* 'POLY' */
+    cpy_r_r40 = CPyStatics[243]; /* 'POLY' */
     CPy_INCREF(cpy_r_r40);
     return cpy_r_r40;
 CPyL47: ;
@@ -14701,7 +14810,7 @@ CPyL51: ;
     } else
         goto CPyL55;
 CPyL54: ;
-    cpy_r_r47 = CPyStatics[242]; /* 'FTM' */
+    cpy_r_r47 = CPyStatics[244]; /* 'FTM' */
     CPy_INCREF(cpy_r_r47);
     return cpy_r_r47;
 CPyL55: ;
@@ -14749,7 +14858,7 @@ CPyL59: ;
     } else
         goto CPyL63;
 CPyL62: ;
-    cpy_r_r54 = CPyStatics[243]; /* 'MOVR' */
+    cpy_r_r54 = CPyStatics[245]; /* 'MOVR' */
     CPy_INCREF(cpy_r_r54);
     return cpy_r_r54;
 CPyL63: ;
@@ -14797,7 +14906,7 @@ CPyL67: ;
     } else
         goto CPyL71;
 CPyL70: ;
-    cpy_r_r61 = CPyStatics[244]; /* 'ARB' */
+    cpy_r_r61 = CPyStatics[246]; /* 'ARB' */
     CPy_INCREF(cpy_r_r61);
     return cpy_r_r61;
 CPyL71: ;
@@ -14845,7 +14954,7 @@ CPyL75: ;
     } else
         goto CPyL79;
 CPyL78: ;
-    cpy_r_r68 = CPyStatics[245]; /* 'AVAX' */
+    cpy_r_r68 = CPyStatics[247]; /* 'AVAX' */
     CPy_INCREF(cpy_r_r68);
     return cpy_r_r68;
 CPyL79: ;
@@ -14893,7 +15002,7 @@ CPyL83: ;
     } else
         goto CPyL87;
 CPyL86: ;
-    cpy_r_r75 = CPyStatics[246]; /* 'ONE' */
+    cpy_r_r75 = CPyStatics[248]; /* 'ONE' */
     CPy_INCREF(cpy_r_r75);
     return cpy_r_r75;
 CPyL87: ;
@@ -14941,7 +15050,7 @@ CPyL91: ;
     } else
         goto CPyL95;
 CPyL94: ;
-    cpy_r_r82 = CPyStatics[247]; /* 'AURORA' */
+    cpy_r_r82 = CPyStatics[249]; /* 'AURORA' */
     CPy_INCREF(cpy_r_r82);
     return cpy_r_r82;
 CPyL95: ;
@@ -14989,7 +15098,7 @@ CPyL99: ;
     } else
         goto CPyL103;
 CPyL102: ;
-    cpy_r_r89 = CPyStatics[248]; /* 'OKEX' */
+    cpy_r_r89 = CPyStatics[250]; /* 'OKEX' */
     CPy_INCREF(cpy_r_r89);
     return cpy_r_r89;
 CPyL103: ;
@@ -15037,7 +15146,7 @@ CPyL107: ;
     } else
         goto CPyL111;
 CPyL110: ;
-    cpy_r_r96 = CPyStatics[249]; /* 'CRO' */
+    cpy_r_r96 = CPyStatics[251]; /* 'CRO' */
     CPy_INCREF(cpy_r_r96);
     return cpy_r_r96;
 CPyL111: ;
@@ -15085,7 +15194,7 @@ CPyL115: ;
     } else
         goto CPyL119;
 CPyL118: ;
-    cpy_r_r103 = CPyStatics[250]; /* 'OPTI' */
+    cpy_r_r103 = CPyStatics[252]; /* 'OPTI' */
     CPy_INCREF(cpy_r_r103);
     return cpy_r_r103;
 CPyL119: ;
@@ -15130,7 +15239,7 @@ CPyL123: ;
         goto CPyL128;
     }
     if (!cpy_r_r109) goto CPyL127;
-    cpy_r_r110 = CPyStatics[251]; /* 'BASE' */
+    cpy_r_r110 = CPyStatics[253]; /* 'BASE' */
     CPy_INCREF(cpy_r_r110);
     return cpy_r_r110;
 CPyL127: ;
@@ -15506,7 +15615,7 @@ CPyL11: ;
     } else
         goto CPyL15;
 CPyL14: ;
-    cpy_r_r12 = CPyStatics[252]; /* 'Mainnet' */
+    cpy_r_r12 = CPyStatics[254]; /* 'Mainnet' */
     CPy_INCREF(cpy_r_r12);
     return cpy_r_r12;
 CPyL15: ;
@@ -15554,7 +15663,7 @@ CPyL19: ;
     } else
         goto CPyL23;
 CPyL22: ;
-    cpy_r_r19 = CPyStatics[253]; /* 'Binance Smart Chain' */
+    cpy_r_r19 = CPyStatics[255]; /* 'Binance Smart Chain' */
     CPy_INCREF(cpy_r_r19);
     return cpy_r_r19;
 CPyL23: ;
@@ -15602,7 +15711,7 @@ CPyL27: ;
     } else
         goto CPyL31;
 CPyL30: ;
-    cpy_r_r26 = CPyStatics[254]; /* 'Gnosis' */
+    cpy_r_r26 = CPyStatics[256]; /* 'Gnosis' */
     CPy_INCREF(cpy_r_r26);
     return cpy_r_r26;
 CPyL31: ;
@@ -15650,7 +15759,7 @@ CPyL35: ;
     } else
         goto CPyL39;
 CPyL38: ;
-    cpy_r_r33 = CPyStatics[255]; /* 'Heco' */
+    cpy_r_r33 = CPyStatics[257]; /* 'Heco' */
     CPy_INCREF(cpy_r_r33);
     return cpy_r_r33;
 CPyL39: ;
@@ -15698,7 +15807,7 @@ CPyL43: ;
     } else
         goto CPyL47;
 CPyL46: ;
-    cpy_r_r40 = CPyStatics[256]; /* 'Polygon' */
+    cpy_r_r40 = CPyStatics[258]; /* 'Polygon' */
     CPy_INCREF(cpy_r_r40);
     return cpy_r_r40;
 CPyL47: ;
@@ -15746,7 +15855,7 @@ CPyL51: ;
     } else
         goto CPyL55;
 CPyL54: ;
-    cpy_r_r47 = CPyStatics[257]; /* 'Fantom' */
+    cpy_r_r47 = CPyStatics[259]; /* 'Fantom' */
     CPy_INCREF(cpy_r_r47);
     return cpy_r_r47;
 CPyL55: ;
@@ -15794,7 +15903,7 @@ CPyL59: ;
     } else
         goto CPyL63;
 CPyL62: ;
-    cpy_r_r54 = CPyStatics[258]; /* 'Moonriver' */
+    cpy_r_r54 = CPyStatics[260]; /* 'Moonriver' */
     CPy_INCREF(cpy_r_r54);
     return cpy_r_r54;
 CPyL63: ;
@@ -15842,7 +15951,7 @@ CPyL67: ;
     } else
         goto CPyL71;
 CPyL70: ;
-    cpy_r_r61 = CPyStatics[259]; /* 'Arbitrum' */
+    cpy_r_r61 = CPyStatics[261]; /* 'Arbitrum' */
     CPy_INCREF(cpy_r_r61);
     return cpy_r_r61;
 CPyL71: ;
@@ -15890,7 +15999,7 @@ CPyL75: ;
     } else
         goto CPyL79;
 CPyL78: ;
-    cpy_r_r68 = CPyStatics[260]; /* 'Avalanche' */
+    cpy_r_r68 = CPyStatics[262]; /* 'Avalanche' */
     CPy_INCREF(cpy_r_r68);
     return cpy_r_r68;
 CPyL79: ;
@@ -15938,7 +16047,7 @@ CPyL83: ;
     } else
         goto CPyL87;
 CPyL86: ;
-    cpy_r_r75 = CPyStatics[261]; /* 'HarmonyOne Shard 0' */
+    cpy_r_r75 = CPyStatics[263]; /* 'HarmonyOne Shard 0' */
     CPy_INCREF(cpy_r_r75);
     return cpy_r_r75;
 CPyL87: ;
@@ -15986,7 +16095,7 @@ CPyL91: ;
     } else
         goto CPyL95;
 CPyL94: ;
-    cpy_r_r82 = CPyStatics[262]; /* 'Aurora' */
+    cpy_r_r82 = CPyStatics[264]; /* 'Aurora' */
     CPy_INCREF(cpy_r_r82);
     return cpy_r_r82;
 CPyL95: ;
@@ -16034,7 +16143,7 @@ CPyL99: ;
     } else
         goto CPyL103;
 CPyL102: ;
-    cpy_r_r89 = CPyStatics[263]; /* 'OKEx' */
+    cpy_r_r89 = CPyStatics[265]; /* 'OKEx' */
     CPy_INCREF(cpy_r_r89);
     return cpy_r_r89;
 CPyL103: ;
@@ -16082,7 +16191,7 @@ CPyL107: ;
     } else
         goto CPyL111;
 CPyL110: ;
-    cpy_r_r96 = CPyStatics[264]; /* 'Cronos' */
+    cpy_r_r96 = CPyStatics[266]; /* 'Cronos' */
     CPy_INCREF(cpy_r_r96);
     return cpy_r_r96;
 CPyL111: ;
@@ -16130,7 +16239,7 @@ CPyL115: ;
     } else
         goto CPyL119;
 CPyL118: ;
-    cpy_r_r103 = CPyStatics[265]; /* 'Optimism' */
+    cpy_r_r103 = CPyStatics[267]; /* 'Optimism' */
     CPy_INCREF(cpy_r_r103);
     return cpy_r_r103;
 CPyL119: ;
@@ -16175,7 +16284,7 @@ CPyL123: ;
         goto CPyL128;
     }
     if (!cpy_r_r109) goto CPyL127;
-    cpy_r_r110 = CPyStatics[266]; /* 'Base' */
+    cpy_r_r110 = CPyStatics[268]; /* 'Base' */
     CPy_INCREF(cpy_r_r110);
     return cpy_r_r110;
 CPyL127: ;
@@ -16425,7 +16534,7 @@ CPyL7: ;
         goto CPyL20;
     }
     cpy_r_r7 = (PyObject *)CPyType_networks___Network;
-    cpy_r_r8 = CPyStatics[267]; /* 'name' */
+    cpy_r_r8 = CPyStatics[269]; /* 'name' */
     cpy_r_r9 = CPyTagged_StealAsObject(cpy_r_r6);
     PyObject *cpy_r_r10[2] = {cpy_r_r7, cpy_r_r9};
     cpy_r_r11 = (PyObject **)&cpy_r_r10;
@@ -16450,7 +16559,7 @@ CPyL11: ;
     cpy_r_r15 = cpy_r_r13;
     goto CPyL16;
 CPyL12: ;
-    cpy_r_r16 = CPyStatics[268]; /* 'chain ' */
+    cpy_r_r16 = CPyStatics[270]; /* 'chain ' */
     if (likely(PyLong_Check(cpy_r_chain_id)))
         cpy_r_r17 = CPyTagged_FromObject(cpy_r_chain_id);
     else {
@@ -16817,8 +16926,8 @@ char CPyDef_networks_____top_level__(void) {
     CPy_INCREF(CPyModule_builtins);
     CPy_DECREF(cpy_r_r4);
 CPyL3: ;
-    cpy_r_r5 = CPyStatics[531]; /* ('IntEnum',) */
-    cpy_r_r6 = CPyStatics[270]; /* 'enum' */
+    cpy_r_r5 = CPyStatics[532]; /* ('IntEnum',) */
+    cpy_r_r6 = CPyStatics[272]; /* 'enum' */
     cpy_r_r7 = CPyStatic_networks___globals;
     cpy_r_r8 = CPyImport_ImportFromMany(cpy_r_r6, cpy_r_r5, cpy_r_r5, cpy_r_r7);
     if (unlikely(cpy_r_r8 == NULL)) {
@@ -16828,7 +16937,7 @@ CPyL3: ;
     CPyModule_enum = cpy_r_r8;
     CPy_INCREF(CPyModule_enum);
     CPy_DECREF(cpy_r_r8);
-    cpy_r_r9 = CPyStatics[532]; /* ('Final', 'Optional', 'final') */
+    cpy_r_r9 = CPyStatics[533]; /* ('Final', 'Optional', 'final') */
     cpy_r_r10 = CPyStatics[37]; /* 'typing' */
     cpy_r_r11 = CPyStatic_networks___globals;
     cpy_r_r12 = CPyImport_ImportFromMany(cpy_r_r10, cpy_r_r9, cpy_r_r9, cpy_r_r11);
@@ -16839,7 +16948,7 @@ CPyL3: ;
     CPyModule_typing = cpy_r_r12;
     CPy_INCREF(CPyModule_typing);
     CPy_DECREF(cpy_r_r12);
-    cpy_r_r13 = CPyStatics[498]; /* ('chain',) */
+    cpy_r_r13 = CPyStatics[499]; /* ('chain',) */
     cpy_r_r14 = CPyStatics[44]; /* 'brownie' */
     cpy_r_r15 = CPyStatic_networks___globals;
     cpy_r_r16 = CPyImport_ImportFromMany(cpy_r_r14, cpy_r_r13, cpy_r_r13, cpy_r_r15);
@@ -16857,7 +16966,7 @@ CPyL3: ;
         CPy_AddTraceback("y/networks.py", "<module>", 7, CPyStatic_networks___globals);
         goto CPyL92;
     }
-    cpy_r_r20 = CPyStatics[65]; /* 'id' */
+    cpy_r_r20 = CPyStatics[71]; /* 'id' */
     cpy_r_r21 = CPyObject_GetAttr(cpy_r_r19, cpy_r_r20);
     CPy_DECREF(cpy_r_r19);
     if (unlikely(cpy_r_r21 == NULL)) {
@@ -16877,7 +16986,7 @@ CPyL3: ;
     CPyStatic_networks___CHAINID = cpy_r_r22;
     CPyTagged_INCREF(CPyStatic_networks___CHAINID);
     cpy_r_r23 = CPyStatic_networks___globals;
-    cpy_r_r24 = CPyStatics[271]; /* 'CHAINID' */
+    cpy_r_r24 = CPyStatics[273]; /* 'CHAINID' */
     cpy_r_r25 = CPyTagged_StealAsObject(cpy_r_r22);
     cpy_r_r26 = CPyDict_SetItem(cpy_r_r23, cpy_r_r24, cpy_r_r25);
     CPy_DECREF(cpy_r_r25);
@@ -16887,7 +16996,7 @@ CPyL3: ;
         goto CPyL92;
     }
     cpy_r_r28 = CPyModule_enum;
-    cpy_r_r29 = CPyStatics[269]; /* 'IntEnum' */
+    cpy_r_r29 = CPyStatics[271]; /* 'IntEnum' */
     cpy_r_r30 = CPyObject_GetAttr(cpy_r_r28, cpy_r_r29);
     if (unlikely(cpy_r_r30 == NULL)) {
         CPy_AddTraceback("y/networks.py", "<module>", 14, CPyStatic_networks___globals);
@@ -16905,11 +17014,11 @@ CPyL3: ;
         CPy_AddTraceback("y/networks.py", "<module>", 14, CPyStatic_networks___globals);
         goto CPyL93;
     }
-    cpy_r_r34 = CPyStatics[272]; /* '__prepare__' */
+    cpy_r_r34 = CPyStatics[274]; /* '__prepare__' */
     cpy_r_r35 = PyObject_HasAttr(cpy_r_r33, cpy_r_r34);
     if (!cpy_r_r35) goto CPyL18;
-    cpy_r_r36 = CPyStatics[171]; /* 'Network' */
-    cpy_r_r37 = CPyStatics[272]; /* '__prepare__' */
+    cpy_r_r36 = CPyStatics[173]; /* 'Network' */
+    cpy_r_r37 = CPyStatics[274]; /* '__prepare__' */
     cpy_r_r38 = CPyObject_GetAttr(cpy_r_r33, cpy_r_r37);
     if (unlikely(cpy_r_r38 == NULL)) {
         CPy_AddTraceback("y/networks.py", "<module>", 14, CPyStatic_networks___globals);
@@ -16945,15 +17054,15 @@ CPyL20: ;
         goto CPyL94;
     }
     cpy_r_r46 = (PyObject *)&PyLong_Type;
-    cpy_r_r47 = CPyStatics[252]; /* 'Mainnet' */
+    cpy_r_r47 = CPyStatics[254]; /* 'Mainnet' */
     cpy_r_r48 = CPyDict_SetItem(cpy_r_r45, cpy_r_r47, cpy_r_r46);
     cpy_r_r49 = cpy_r_r48 >= 0;
     if (unlikely(!cpy_r_r49)) {
         CPy_AddTraceback("y/networks.py", "<module>", 31, CPyStatic_networks___globals);
         goto CPyL95;
     }
-    cpy_r_r50 = CPyStatics[252]; /* 'Mainnet' */
-    cpy_r_r51 = CPyStatics[472]; /* 1 */
+    cpy_r_r50 = CPyStatics[254]; /* 'Mainnet' */
+    cpy_r_r51 = CPyStatics[473]; /* 1 */
     cpy_r_r52 = CPyDict_SetItem(cpy_r_r43, cpy_r_r50, cpy_r_r51);
     cpy_r_r53 = cpy_r_r52 >= 0;
     if (unlikely(!cpy_r_r53)) {
@@ -16961,15 +17070,15 @@ CPyL20: ;
         goto CPyL95;
     }
     cpy_r_r54 = (PyObject *)&PyLong_Type;
-    cpy_r_r55 = CPyStatics[265]; /* 'Optimism' */
+    cpy_r_r55 = CPyStatics[267]; /* 'Optimism' */
     cpy_r_r56 = CPyDict_SetItem(cpy_r_r45, cpy_r_r55, cpy_r_r54);
     cpy_r_r57 = cpy_r_r56 >= 0;
     if (unlikely(!cpy_r_r57)) {
         CPy_AddTraceback("y/networks.py", "<module>", 34, CPyStatic_networks___globals);
         goto CPyL95;
     }
-    cpy_r_r58 = CPyStatics[265]; /* 'Optimism' */
-    cpy_r_r59 = CPyStatics[466]; /* 10 */
+    cpy_r_r58 = CPyStatics[267]; /* 'Optimism' */
+    cpy_r_r59 = CPyStatics[468]; /* 10 */
     cpy_r_r60 = CPyDict_SetItem(cpy_r_r43, cpy_r_r58, cpy_r_r59);
     cpy_r_r61 = cpy_r_r60 >= 0;
     if (unlikely(!cpy_r_r61)) {
@@ -16977,15 +17086,15 @@ CPyL20: ;
         goto CPyL95;
     }
     cpy_r_r62 = (PyObject *)&PyLong_Type;
-    cpy_r_r63 = CPyStatics[264]; /* 'Cronos' */
+    cpy_r_r63 = CPyStatics[266]; /* 'Cronos' */
     cpy_r_r64 = CPyDict_SetItem(cpy_r_r45, cpy_r_r63, cpy_r_r62);
     cpy_r_r65 = cpy_r_r64 >= 0;
     if (unlikely(!cpy_r_r65)) {
         CPy_AddTraceback("y/networks.py", "<module>", 37, CPyStatic_networks___globals);
         goto CPyL95;
     }
-    cpy_r_r66 = CPyStatics[264]; /* 'Cronos' */
-    cpy_r_r67 = CPyStatics[473]; /* 25 */
+    cpy_r_r66 = CPyStatics[266]; /* 'Cronos' */
+    cpy_r_r67 = CPyStatics[474]; /* 25 */
     cpy_r_r68 = CPyDict_SetItem(cpy_r_r43, cpy_r_r66, cpy_r_r67);
     cpy_r_r69 = cpy_r_r68 >= 0;
     if (unlikely(!cpy_r_r69)) {
@@ -16993,15 +17102,15 @@ CPyL20: ;
         goto CPyL95;
     }
     cpy_r_r70 = (PyObject *)&PyLong_Type;
-    cpy_r_r71 = CPyStatics[273]; /* 'BinanceSmartChain' */
+    cpy_r_r71 = CPyStatics[275]; /* 'BinanceSmartChain' */
     cpy_r_r72 = CPyDict_SetItem(cpy_r_r45, cpy_r_r71, cpy_r_r70);
     cpy_r_r73 = cpy_r_r72 >= 0;
     if (unlikely(!cpy_r_r73)) {
         CPy_AddTraceback("y/networks.py", "<module>", 40, CPyStatic_networks___globals);
         goto CPyL95;
     }
-    cpy_r_r74 = CPyStatics[273]; /* 'BinanceSmartChain' */
-    cpy_r_r75 = CPyStatics[474]; /* 56 */
+    cpy_r_r74 = CPyStatics[275]; /* 'BinanceSmartChain' */
+    cpy_r_r75 = CPyStatics[475]; /* 56 */
     cpy_r_r76 = CPyDict_SetItem(cpy_r_r43, cpy_r_r74, cpy_r_r75);
     cpy_r_r77 = cpy_r_r76 >= 0;
     if (unlikely(!cpy_r_r77)) {
@@ -17009,15 +17118,15 @@ CPyL20: ;
         goto CPyL95;
     }
     cpy_r_r78 = (PyObject *)&PyLong_Type;
-    cpy_r_r79 = CPyStatics[263]; /* 'OKEx' */
+    cpy_r_r79 = CPyStatics[265]; /* 'OKEx' */
     cpy_r_r80 = CPyDict_SetItem(cpy_r_r45, cpy_r_r79, cpy_r_r78);
     cpy_r_r81 = cpy_r_r80 >= 0;
     if (unlikely(!cpy_r_r81)) {
         CPy_AddTraceback("y/networks.py", "<module>", 43, CPyStatic_networks___globals);
         goto CPyL95;
     }
-    cpy_r_r82 = CPyStatics[263]; /* 'OKEx' */
-    cpy_r_r83 = CPyStatics[475]; /* 66 */
+    cpy_r_r82 = CPyStatics[265]; /* 'OKEx' */
+    cpy_r_r83 = CPyStatics[476]; /* 66 */
     cpy_r_r84 = CPyDict_SetItem(cpy_r_r43, cpy_r_r82, cpy_r_r83);
     cpy_r_r85 = cpy_r_r84 >= 0;
     if (unlikely(!cpy_r_r85)) {
@@ -17025,15 +17134,15 @@ CPyL20: ;
         goto CPyL95;
     }
     cpy_r_r86 = (PyObject *)&PyLong_Type;
-    cpy_r_r87 = CPyStatics[254]; /* 'Gnosis' */
+    cpy_r_r87 = CPyStatics[256]; /* 'Gnosis' */
     cpy_r_r88 = CPyDict_SetItem(cpy_r_r45, cpy_r_r87, cpy_r_r86);
     cpy_r_r89 = cpy_r_r88 >= 0;
     if (unlikely(!cpy_r_r89)) {
         CPy_AddTraceback("y/networks.py", "<module>", 46, CPyStatic_networks___globals);
         goto CPyL95;
     }
-    cpy_r_r90 = CPyStatics[254]; /* 'Gnosis' */
-    cpy_r_r91 = CPyStatics[476]; /* 100 */
+    cpy_r_r90 = CPyStatics[256]; /* 'Gnosis' */
+    cpy_r_r91 = CPyStatics[477]; /* 100 */
     cpy_r_r92 = CPyDict_SetItem(cpy_r_r43, cpy_r_r90, cpy_r_r91);
     cpy_r_r93 = cpy_r_r92 >= 0;
     if (unlikely(!cpy_r_r93)) {
@@ -17041,15 +17150,15 @@ CPyL20: ;
         goto CPyL95;
     }
     cpy_r_r94 = (PyObject *)&PyLong_Type;
-    cpy_r_r95 = CPyStatics[274]; /* 'xDai' */
+    cpy_r_r95 = CPyStatics[276]; /* 'xDai' */
     cpy_r_r96 = CPyDict_SetItem(cpy_r_r45, cpy_r_r95, cpy_r_r94);
     cpy_r_r97 = cpy_r_r96 >= 0;
     if (unlikely(!cpy_r_r97)) {
         CPy_AddTraceback("y/networks.py", "<module>", 49, CPyStatic_networks___globals);
         goto CPyL95;
     }
-    cpy_r_r98 = CPyStatics[274]; /* 'xDai' */
-    cpy_r_r99 = CPyStatics[476]; /* 100 */
+    cpy_r_r98 = CPyStatics[276]; /* 'xDai' */
+    cpy_r_r99 = CPyStatics[477]; /* 100 */
     cpy_r_r100 = CPyDict_SetItem(cpy_r_r43, cpy_r_r98, cpy_r_r99);
     cpy_r_r101 = cpy_r_r100 >= 0;
     if (unlikely(!cpy_r_r101)) {
@@ -17057,15 +17166,15 @@ CPyL20: ;
         goto CPyL95;
     }
     cpy_r_r102 = (PyObject *)&PyLong_Type;
-    cpy_r_r103 = CPyStatics[255]; /* 'Heco' */
+    cpy_r_r103 = CPyStatics[257]; /* 'Heco' */
     cpy_r_r104 = CPyDict_SetItem(cpy_r_r45, cpy_r_r103, cpy_r_r102);
     cpy_r_r105 = cpy_r_r104 >= 0;
     if (unlikely(!cpy_r_r105)) {
         CPy_AddTraceback("y/networks.py", "<module>", 52, CPyStatic_networks___globals);
         goto CPyL95;
     }
-    cpy_r_r106 = CPyStatics[255]; /* 'Heco' */
-    cpy_r_r107 = CPyStatics[477]; /* 128 */
+    cpy_r_r106 = CPyStatics[257]; /* 'Heco' */
+    cpy_r_r107 = CPyStatics[478]; /* 128 */
     cpy_r_r108 = CPyDict_SetItem(cpy_r_r43, cpy_r_r106, cpy_r_r107);
     cpy_r_r109 = cpy_r_r108 >= 0;
     if (unlikely(!cpy_r_r109)) {
@@ -17073,15 +17182,15 @@ CPyL20: ;
         goto CPyL95;
     }
     cpy_r_r110 = (PyObject *)&PyLong_Type;
-    cpy_r_r111 = CPyStatics[256]; /* 'Polygon' */
+    cpy_r_r111 = CPyStatics[258]; /* 'Polygon' */
     cpy_r_r112 = CPyDict_SetItem(cpy_r_r45, cpy_r_r111, cpy_r_r110);
     cpy_r_r113 = cpy_r_r112 >= 0;
     if (unlikely(!cpy_r_r113)) {
         CPy_AddTraceback("y/networks.py", "<module>", 55, CPyStatic_networks___globals);
         goto CPyL95;
     }
-    cpy_r_r114 = CPyStatics[256]; /* 'Polygon' */
-    cpy_r_r115 = CPyStatics[478]; /* 137 */
+    cpy_r_r114 = CPyStatics[258]; /* 'Polygon' */
+    cpy_r_r115 = CPyStatics[479]; /* 137 */
     cpy_r_r116 = CPyDict_SetItem(cpy_r_r43, cpy_r_r114, cpy_r_r115);
     cpy_r_r117 = cpy_r_r116 >= 0;
     if (unlikely(!cpy_r_r117)) {
@@ -17089,15 +17198,15 @@ CPyL20: ;
         goto CPyL95;
     }
     cpy_r_r118 = (PyObject *)&PyLong_Type;
-    cpy_r_r119 = CPyStatics[257]; /* 'Fantom' */
+    cpy_r_r119 = CPyStatics[259]; /* 'Fantom' */
     cpy_r_r120 = CPyDict_SetItem(cpy_r_r45, cpy_r_r119, cpy_r_r118);
     cpy_r_r121 = cpy_r_r120 >= 0;
     if (unlikely(!cpy_r_r121)) {
         CPy_AddTraceback("y/networks.py", "<module>", 58, CPyStatic_networks___globals);
         goto CPyL95;
     }
-    cpy_r_r122 = CPyStatics[257]; /* 'Fantom' */
-    cpy_r_r123 = CPyStatics[479]; /* 250 */
+    cpy_r_r122 = CPyStatics[259]; /* 'Fantom' */
+    cpy_r_r123 = CPyStatics[480]; /* 250 */
     cpy_r_r124 = CPyDict_SetItem(cpy_r_r43, cpy_r_r122, cpy_r_r123);
     cpy_r_r125 = cpy_r_r124 >= 0;
     if (unlikely(!cpy_r_r125)) {
@@ -17105,15 +17214,15 @@ CPyL20: ;
         goto CPyL95;
     }
     cpy_r_r126 = (PyObject *)&PyLong_Type;
-    cpy_r_r127 = CPyStatics[258]; /* 'Moonriver' */
+    cpy_r_r127 = CPyStatics[260]; /* 'Moonriver' */
     cpy_r_r128 = CPyDict_SetItem(cpy_r_r45, cpy_r_r127, cpy_r_r126);
     cpy_r_r129 = cpy_r_r128 >= 0;
     if (unlikely(!cpy_r_r129)) {
         CPy_AddTraceback("y/networks.py", "<module>", 61, CPyStatic_networks___globals);
         goto CPyL95;
     }
-    cpy_r_r130 = CPyStatics[258]; /* 'Moonriver' */
-    cpy_r_r131 = CPyStatics[480]; /* 1285 */
+    cpy_r_r130 = CPyStatics[260]; /* 'Moonriver' */
+    cpy_r_r131 = CPyStatics[481]; /* 1285 */
     cpy_r_r132 = CPyDict_SetItem(cpy_r_r43, cpy_r_r130, cpy_r_r131);
     cpy_r_r133 = cpy_r_r132 >= 0;
     if (unlikely(!cpy_r_r133)) {
@@ -17121,15 +17230,15 @@ CPyL20: ;
         goto CPyL95;
     }
     cpy_r_r134 = (PyObject *)&PyLong_Type;
-    cpy_r_r135 = CPyStatics[266]; /* 'Base' */
+    cpy_r_r135 = CPyStatics[268]; /* 'Base' */
     cpy_r_r136 = CPyDict_SetItem(cpy_r_r45, cpy_r_r135, cpy_r_r134);
     cpy_r_r137 = cpy_r_r136 >= 0;
     if (unlikely(!cpy_r_r137)) {
         CPy_AddTraceback("y/networks.py", "<module>", 64, CPyStatic_networks___globals);
         goto CPyL95;
     }
-    cpy_r_r138 = CPyStatics[266]; /* 'Base' */
-    cpy_r_r139 = CPyStatics[481]; /* 8453 */
+    cpy_r_r138 = CPyStatics[268]; /* 'Base' */
+    cpy_r_r139 = CPyStatics[482]; /* 8453 */
     cpy_r_r140 = CPyDict_SetItem(cpy_r_r43, cpy_r_r138, cpy_r_r139);
     cpy_r_r141 = cpy_r_r140 >= 0;
     if (unlikely(!cpy_r_r141)) {
@@ -17137,15 +17246,15 @@ CPyL20: ;
         goto CPyL95;
     }
     cpy_r_r142 = (PyObject *)&PyLong_Type;
-    cpy_r_r143 = CPyStatics[259]; /* 'Arbitrum' */
+    cpy_r_r143 = CPyStatics[261]; /* 'Arbitrum' */
     cpy_r_r144 = CPyDict_SetItem(cpy_r_r45, cpy_r_r143, cpy_r_r142);
     cpy_r_r145 = cpy_r_r144 >= 0;
     if (unlikely(!cpy_r_r145)) {
         CPy_AddTraceback("y/networks.py", "<module>", 67, CPyStatic_networks___globals);
         goto CPyL95;
     }
-    cpy_r_r146 = CPyStatics[259]; /* 'Arbitrum' */
-    cpy_r_r147 = CPyStatics[482]; /* 42161 */
+    cpy_r_r146 = CPyStatics[261]; /* 'Arbitrum' */
+    cpy_r_r147 = CPyStatics[483]; /* 42161 */
     cpy_r_r148 = CPyDict_SetItem(cpy_r_r43, cpy_r_r146, cpy_r_r147);
     cpy_r_r149 = cpy_r_r148 >= 0;
     if (unlikely(!cpy_r_r149)) {
@@ -17153,15 +17262,15 @@ CPyL20: ;
         goto CPyL95;
     }
     cpy_r_r150 = (PyObject *)&PyLong_Type;
-    cpy_r_r151 = CPyStatics[260]; /* 'Avalanche' */
+    cpy_r_r151 = CPyStatics[262]; /* 'Avalanche' */
     cpy_r_r152 = CPyDict_SetItem(cpy_r_r45, cpy_r_r151, cpy_r_r150);
     cpy_r_r153 = cpy_r_r152 >= 0;
     if (unlikely(!cpy_r_r153)) {
         CPy_AddTraceback("y/networks.py", "<module>", 70, CPyStatic_networks___globals);
         goto CPyL95;
     }
-    cpy_r_r154 = CPyStatics[260]; /* 'Avalanche' */
-    cpy_r_r155 = CPyStatics[483]; /* 43114 */
+    cpy_r_r154 = CPyStatics[262]; /* 'Avalanche' */
+    cpy_r_r155 = CPyStatics[484]; /* 43114 */
     cpy_r_r156 = CPyDict_SetItem(cpy_r_r43, cpy_r_r154, cpy_r_r155);
     cpy_r_r157 = cpy_r_r156 >= 0;
     if (unlikely(!cpy_r_r157)) {
@@ -17169,15 +17278,15 @@ CPyL20: ;
         goto CPyL95;
     }
     cpy_r_r158 = (PyObject *)&PyLong_Type;
-    cpy_r_r159 = CPyStatics[275]; /* 'Harmony' */
+    cpy_r_r159 = CPyStatics[277]; /* 'Harmony' */
     cpy_r_r160 = CPyDict_SetItem(cpy_r_r45, cpy_r_r159, cpy_r_r158);
     cpy_r_r161 = cpy_r_r160 >= 0;
     if (unlikely(!cpy_r_r161)) {
         CPy_AddTraceback("y/networks.py", "<module>", 73, CPyStatic_networks___globals);
         goto CPyL95;
     }
-    cpy_r_r162 = CPyStatics[275]; /* 'Harmony' */
-    cpy_r_r163 = CPyStatics[484]; /* 1666600000 */
+    cpy_r_r162 = CPyStatics[277]; /* 'Harmony' */
+    cpy_r_r163 = CPyStatics[485]; /* 1666600000 */
     cpy_r_r164 = CPyDict_SetItem(cpy_r_r43, cpy_r_r162, cpy_r_r163);
     cpy_r_r165 = cpy_r_r164 >= 0;
     if (unlikely(!cpy_r_r165)) {
@@ -17185,15 +17294,15 @@ CPyL20: ;
         goto CPyL95;
     }
     cpy_r_r166 = (PyObject *)&PyLong_Type;
-    cpy_r_r167 = CPyStatics[262]; /* 'Aurora' */
+    cpy_r_r167 = CPyStatics[264]; /* 'Aurora' */
     cpy_r_r168 = CPyDict_SetItem(cpy_r_r45, cpy_r_r167, cpy_r_r166);
     cpy_r_r169 = cpy_r_r168 >= 0;
     if (unlikely(!cpy_r_r169)) {
         CPy_AddTraceback("y/networks.py", "<module>", 76, CPyStatic_networks___globals);
         goto CPyL95;
     }
-    cpy_r_r170 = CPyStatics[262]; /* 'Aurora' */
-    cpy_r_r171 = CPyStatics[485]; /* 1313161554 */
+    cpy_r_r170 = CPyStatics[264]; /* 'Aurora' */
+    cpy_r_r171 = CPyStatics[486]; /* 1313161554 */
     cpy_r_r172 = CPyDict_SetItem(cpy_r_r43, cpy_r_r170, cpy_r_r171);
     cpy_r_r173 = cpy_r_r172 >= 0;
     if (unlikely(!cpy_r_r173)) {
@@ -17206,7 +17315,7 @@ CPyL20: ;
         goto CPyL95;
     }
     cpy_r_r175 = CPyModule_builtins;
-    cpy_r_r176 = CPyStatics[276]; /* 'staticmethod' */
+    cpy_r_r176 = CPyStatics[278]; /* 'staticmethod' */
     cpy_r_r177 = CPyObject_GetAttr(cpy_r_r175, cpy_r_r176);
     if (unlikely(cpy_r_r177 == NULL)) {
         CPy_AddTraceback("y/networks.py", "<module>", 80, CPyStatic_networks___globals);
@@ -17221,7 +17330,7 @@ CPyL20: ;
         goto CPyL96;
     }
     CPy_DECREF_NO_IMM(cpy_r_r174);
-    cpy_r_r181 = CPyStatics[277]; /* 'label' */
+    cpy_r_r181 = CPyStatics[279]; /* 'label' */
     cpy_r_r182 = CPyDict_SetItem(cpy_r_r43, cpy_r_r181, cpy_r_r180);
     CPy_DECREF(cpy_r_r180);
     cpy_r_r183 = cpy_r_r182 >= 0;
@@ -17235,7 +17344,7 @@ CPyL20: ;
         goto CPyL95;
     }
     cpy_r_r185 = CPyModule_builtins;
-    cpy_r_r186 = CPyStatics[276]; /* 'staticmethod' */
+    cpy_r_r186 = CPyStatics[278]; /* 'staticmethod' */
     cpy_r_r187 = CPyObject_GetAttr(cpy_r_r185, cpy_r_r186);
     if (unlikely(cpy_r_r187 == NULL)) {
         CPy_AddTraceback("y/networks.py", "<module>", 133, CPyStatic_networks___globals);
@@ -17250,7 +17359,7 @@ CPyL20: ;
         goto CPyL97;
     }
     CPy_DECREF_NO_IMM(cpy_r_r184);
-    cpy_r_r191 = CPyStatics[267]; /* 'name' */
+    cpy_r_r191 = CPyStatics[269]; /* 'name' */
     cpy_r_r192 = CPyDict_SetItem(cpy_r_r43, cpy_r_r191, cpy_r_r190);
     CPy_DECREF(cpy_r_r190);
     cpy_r_r193 = cpy_r_r192 >= 0;
@@ -17264,7 +17373,7 @@ CPyL20: ;
         goto CPyL95;
     }
     cpy_r_r195 = CPyModule_builtins;
-    cpy_r_r196 = CPyStatics[276]; /* 'staticmethod' */
+    cpy_r_r196 = CPyStatics[278]; /* 'staticmethod' */
     cpy_r_r197 = CPyObject_GetAttr(cpy_r_r195, cpy_r_r196);
     if (unlikely(cpy_r_r197 == NULL)) {
         CPy_AddTraceback("y/networks.py", "<module>", 186, CPyStatic_networks___globals);
@@ -17279,7 +17388,7 @@ CPyL20: ;
         goto CPyL98;
     }
     CPy_DECREF_NO_IMM(cpy_r_r194);
-    cpy_r_r201 = CPyStatics[175]; /* 'printable' */
+    cpy_r_r201 = CPyStatics[177]; /* 'printable' */
     cpy_r_r202 = CPyDict_SetItem(cpy_r_r43, cpy_r_r201, cpy_r_r200);
     CPy_DECREF(cpy_r_r200);
     cpy_r_r203 = cpy_r_r202 >= 0;
@@ -17287,8 +17396,8 @@ CPyL20: ;
         CPy_AddTraceback("y/networks.py", "<module>", 186, CPyStatic_networks___globals);
         goto CPyL95;
     }
-    cpy_r_r204 = CPyStatics[171]; /* 'Network' */
-    cpy_r_r205 = CPyStatics[278]; /* '__annotations__' */
+    cpy_r_r204 = CPyStatics[173]; /* 'Network' */
+    cpy_r_r205 = CPyStatics[280]; /* '__annotations__' */
     cpy_r_r206 = CPyDict_SetItem(cpy_r_r43, cpy_r_r205, cpy_r_r45);
     CPy_DECREF(cpy_r_r45);
     cpy_r_r207 = cpy_r_r206 >= 0;
@@ -17296,15 +17405,15 @@ CPyL20: ;
         CPy_AddTraceback("y/networks.py", "<module>", 14, CPyStatic_networks___globals);
         goto CPyL94;
     }
-    cpy_r_r208 = CPyStatics[279]; /* 'mypyc filler docstring' */
-    cpy_r_r209 = CPyStatics[280]; /* '__doc__' */
+    cpy_r_r208 = CPyStatics[281]; /* 'mypyc filler docstring' */
+    cpy_r_r209 = CPyStatics[282]; /* '__doc__' */
     cpy_r_r210 = CPyDict_SetItem(cpy_r_r43, cpy_r_r209, cpy_r_r208);
     cpy_r_r211 = cpy_r_r210 >= 0;
     if (unlikely(!cpy_r_r211)) {
         CPy_AddTraceback("y/networks.py", "<module>", 14, CPyStatic_networks___globals);
         goto CPyL94;
     }
-    cpy_r_r212 = CPyStatics[281]; /* 'y.networks' */
+    cpy_r_r212 = CPyStatics[283]; /* 'y.networks' */
     cpy_r_r213 = CPyStatics[8]; /* '__module__' */
     cpy_r_r214 = CPyDict_SetItem(cpy_r_r43, cpy_r_r213, cpy_r_r212);
     cpy_r_r215 = cpy_r_r214 >= 0;
@@ -17322,7 +17431,7 @@ CPyL20: ;
     CPy_DECREF(cpy_r_r31);
     CPy_DECREF(cpy_r_r43);
     cpy_r_r219 = CPyStatic_networks___globals;
-    cpy_r_r220 = CPyStatics[209]; /* 'final' */
+    cpy_r_r220 = CPyStatics[211]; /* 'final' */
     cpy_r_r221 = CPyDict_GetItem(cpy_r_r219, cpy_r_r220);
     if (unlikely(cpy_r_r221 == NULL)) {
         CPy_AddTraceback("y/networks.py", "<module>", 13, CPyStatic_networks___globals);
@@ -17340,7 +17449,7 @@ CPyL20: ;
     CPyType_networks___Network = (PyTypeObject *)cpy_r_r224;
     CPy_INCREF(CPyType_networks___Network);
     cpy_r_r225 = CPyStatic_networks___globals;
-    cpy_r_r226 = CPyStatics[171]; /* 'Network' */
+    cpy_r_r226 = CPyStatics[173]; /* 'Network' */
     cpy_r_r227 = CPyDict_SetItem(cpy_r_r225, cpy_r_r226, cpy_r_r224);
     CPy_DECREF(cpy_r_r224);
     cpy_r_r228 = cpy_r_r227 >= 0;
@@ -17349,7 +17458,7 @@ CPyL20: ;
         goto CPyL92;
     }
     cpy_r_r229 = (PyObject *)CPyType_networks___Network;
-    cpy_r_r230 = CPyStatics[252]; /* 'Mainnet' */
+    cpy_r_r230 = CPyStatics[254]; /* 'Mainnet' */
     cpy_r_r231 = CPyObject_GetAttr(cpy_r_r229, cpy_r_r230);
     if (unlikely(cpy_r_r231 == NULL)) {
         CPy_AddTraceback("y/networks.py", "<module>", 14, CPyStatic_networks___globals);
@@ -17358,7 +17467,7 @@ CPyL20: ;
     CPyStatic_networks___Network___Mainnet = cpy_r_r231;
     CPy_INCREF(CPyStatic_networks___Network___Mainnet);
     CPy_DECREF(cpy_r_r231);
-    cpy_r_r232 = CPyStatics[265]; /* 'Optimism' */
+    cpy_r_r232 = CPyStatics[267]; /* 'Optimism' */
     cpy_r_r233 = CPyObject_GetAttr(cpy_r_r229, cpy_r_r232);
     if (unlikely(cpy_r_r233 == NULL)) {
         CPy_AddTraceback("y/networks.py", "<module>", 14, CPyStatic_networks___globals);
@@ -17367,7 +17476,7 @@ CPyL20: ;
     CPyStatic_networks___Network___Optimism = cpy_r_r233;
     CPy_INCREF(CPyStatic_networks___Network___Optimism);
     CPy_DECREF(cpy_r_r233);
-    cpy_r_r234 = CPyStatics[264]; /* 'Cronos' */
+    cpy_r_r234 = CPyStatics[266]; /* 'Cronos' */
     cpy_r_r235 = CPyObject_GetAttr(cpy_r_r229, cpy_r_r234);
     if (unlikely(cpy_r_r235 == NULL)) {
         CPy_AddTraceback("y/networks.py", "<module>", 14, CPyStatic_networks___globals);
@@ -17376,7 +17485,7 @@ CPyL20: ;
     CPyStatic_networks___Network___Cronos = cpy_r_r235;
     CPy_INCREF(CPyStatic_networks___Network___Cronos);
     CPy_DECREF(cpy_r_r235);
-    cpy_r_r236 = CPyStatics[273]; /* 'BinanceSmartChain' */
+    cpy_r_r236 = CPyStatics[275]; /* 'BinanceSmartChain' */
     cpy_r_r237 = CPyObject_GetAttr(cpy_r_r229, cpy_r_r236);
     if (unlikely(cpy_r_r237 == NULL)) {
         CPy_AddTraceback("y/networks.py", "<module>", 14, CPyStatic_networks___globals);
@@ -17385,7 +17494,7 @@ CPyL20: ;
     CPyStatic_networks___Network___BinanceSmartChain = cpy_r_r237;
     CPy_INCREF(CPyStatic_networks___Network___BinanceSmartChain);
     CPy_DECREF(cpy_r_r237);
-    cpy_r_r238 = CPyStatics[263]; /* 'OKEx' */
+    cpy_r_r238 = CPyStatics[265]; /* 'OKEx' */
     cpy_r_r239 = CPyObject_GetAttr(cpy_r_r229, cpy_r_r238);
     if (unlikely(cpy_r_r239 == NULL)) {
         CPy_AddTraceback("y/networks.py", "<module>", 14, CPyStatic_networks___globals);
@@ -17394,7 +17503,7 @@ CPyL20: ;
     CPyStatic_networks___Network___OKEx = cpy_r_r239;
     CPy_INCREF(CPyStatic_networks___Network___OKEx);
     CPy_DECREF(cpy_r_r239);
-    cpy_r_r240 = CPyStatics[254]; /* 'Gnosis' */
+    cpy_r_r240 = CPyStatics[256]; /* 'Gnosis' */
     cpy_r_r241 = CPyObject_GetAttr(cpy_r_r229, cpy_r_r240);
     if (unlikely(cpy_r_r241 == NULL)) {
         CPy_AddTraceback("y/networks.py", "<module>", 14, CPyStatic_networks___globals);
@@ -17403,7 +17512,7 @@ CPyL20: ;
     CPyStatic_networks___Network___Gnosis = cpy_r_r241;
     CPy_INCREF(CPyStatic_networks___Network___Gnosis);
     CPy_DECREF(cpy_r_r241);
-    cpy_r_r242 = CPyStatics[274]; /* 'xDai' */
+    cpy_r_r242 = CPyStatics[276]; /* 'xDai' */
     cpy_r_r243 = CPyObject_GetAttr(cpy_r_r229, cpy_r_r242);
     if (unlikely(cpy_r_r243 == NULL)) {
         CPy_AddTraceback("y/networks.py", "<module>", 14, CPyStatic_networks___globals);
@@ -17412,7 +17521,7 @@ CPyL20: ;
     CPyStatic_networks___Network___xDai = cpy_r_r243;
     CPy_INCREF(CPyStatic_networks___Network___xDai);
     CPy_DECREF(cpy_r_r243);
-    cpy_r_r244 = CPyStatics[255]; /* 'Heco' */
+    cpy_r_r244 = CPyStatics[257]; /* 'Heco' */
     cpy_r_r245 = CPyObject_GetAttr(cpy_r_r229, cpy_r_r244);
     if (unlikely(cpy_r_r245 == NULL)) {
         CPy_AddTraceback("y/networks.py", "<module>", 14, CPyStatic_networks___globals);
@@ -17421,7 +17530,7 @@ CPyL20: ;
     CPyStatic_networks___Network___Heco = cpy_r_r245;
     CPy_INCREF(CPyStatic_networks___Network___Heco);
     CPy_DECREF(cpy_r_r245);
-    cpy_r_r246 = CPyStatics[256]; /* 'Polygon' */
+    cpy_r_r246 = CPyStatics[258]; /* 'Polygon' */
     cpy_r_r247 = CPyObject_GetAttr(cpy_r_r229, cpy_r_r246);
     if (unlikely(cpy_r_r247 == NULL)) {
         CPy_AddTraceback("y/networks.py", "<module>", 14, CPyStatic_networks___globals);
@@ -17430,7 +17539,7 @@ CPyL20: ;
     CPyStatic_networks___Network___Polygon = cpy_r_r247;
     CPy_INCREF(CPyStatic_networks___Network___Polygon);
     CPy_DECREF(cpy_r_r247);
-    cpy_r_r248 = CPyStatics[257]; /* 'Fantom' */
+    cpy_r_r248 = CPyStatics[259]; /* 'Fantom' */
     cpy_r_r249 = CPyObject_GetAttr(cpy_r_r229, cpy_r_r248);
     if (unlikely(cpy_r_r249 == NULL)) {
         CPy_AddTraceback("y/networks.py", "<module>", 14, CPyStatic_networks___globals);
@@ -17439,7 +17548,7 @@ CPyL20: ;
     CPyStatic_networks___Network___Fantom = cpy_r_r249;
     CPy_INCREF(CPyStatic_networks___Network___Fantom);
     CPy_DECREF(cpy_r_r249);
-    cpy_r_r250 = CPyStatics[258]; /* 'Moonriver' */
+    cpy_r_r250 = CPyStatics[260]; /* 'Moonriver' */
     cpy_r_r251 = CPyObject_GetAttr(cpy_r_r229, cpy_r_r250);
     if (unlikely(cpy_r_r251 == NULL)) {
         CPy_AddTraceback("y/networks.py", "<module>", 14, CPyStatic_networks___globals);
@@ -17448,7 +17557,7 @@ CPyL20: ;
     CPyStatic_networks___Network___Moonriver = cpy_r_r251;
     CPy_INCREF(CPyStatic_networks___Network___Moonriver);
     CPy_DECREF(cpy_r_r251);
-    cpy_r_r252 = CPyStatics[266]; /* 'Base' */
+    cpy_r_r252 = CPyStatics[268]; /* 'Base' */
     cpy_r_r253 = CPyObject_GetAttr(cpy_r_r229, cpy_r_r252);
     if (unlikely(cpy_r_r253 == NULL)) {
         CPy_AddTraceback("y/networks.py", "<module>", 14, CPyStatic_networks___globals);
@@ -17457,7 +17566,7 @@ CPyL20: ;
     CPyStatic_networks___Network___Base = cpy_r_r253;
     CPy_INCREF(CPyStatic_networks___Network___Base);
     CPy_DECREF(cpy_r_r253);
-    cpy_r_r254 = CPyStatics[259]; /* 'Arbitrum' */
+    cpy_r_r254 = CPyStatics[261]; /* 'Arbitrum' */
     cpy_r_r255 = CPyObject_GetAttr(cpy_r_r229, cpy_r_r254);
     if (unlikely(cpy_r_r255 == NULL)) {
         CPy_AddTraceback("y/networks.py", "<module>", 14, CPyStatic_networks___globals);
@@ -17466,7 +17575,7 @@ CPyL20: ;
     CPyStatic_networks___Network___Arbitrum = cpy_r_r255;
     CPy_INCREF(CPyStatic_networks___Network___Arbitrum);
     CPy_DECREF(cpy_r_r255);
-    cpy_r_r256 = CPyStatics[260]; /* 'Avalanche' */
+    cpy_r_r256 = CPyStatics[262]; /* 'Avalanche' */
     cpy_r_r257 = CPyObject_GetAttr(cpy_r_r229, cpy_r_r256);
     if (unlikely(cpy_r_r257 == NULL)) {
         CPy_AddTraceback("y/networks.py", "<module>", 14, CPyStatic_networks___globals);
@@ -17475,7 +17584,7 @@ CPyL20: ;
     CPyStatic_networks___Network___Avalanche = cpy_r_r257;
     CPy_INCREF(CPyStatic_networks___Network___Avalanche);
     CPy_DECREF(cpy_r_r257);
-    cpy_r_r258 = CPyStatics[275]; /* 'Harmony' */
+    cpy_r_r258 = CPyStatics[277]; /* 'Harmony' */
     cpy_r_r259 = CPyObject_GetAttr(cpy_r_r229, cpy_r_r258);
     if (unlikely(cpy_r_r259 == NULL)) {
         CPy_AddTraceback("y/networks.py", "<module>", 14, CPyStatic_networks___globals);
@@ -17484,7 +17593,7 @@ CPyL20: ;
     CPyStatic_networks___Network___Harmony = cpy_r_r259;
     CPy_INCREF(CPyStatic_networks___Network___Harmony);
     CPy_DECREF(cpy_r_r259);
-    cpy_r_r260 = CPyStatics[262]; /* 'Aurora' */
+    cpy_r_r260 = CPyStatics[264]; /* 'Aurora' */
     cpy_r_r261 = CPyObject_GetAttr(cpy_r_r229, cpy_r_r260);
     if (unlikely(cpy_r_r261 == NULL)) {
         CPy_AddTraceback("y/networks.py", "<module>", 14, CPyStatic_networks___globals);
@@ -17494,7 +17603,7 @@ CPyL20: ;
     CPy_INCREF(CPyStatic_networks___Network___Aurora);
     CPy_DECREF(cpy_r_r261);
     cpy_r_r262 = (PyObject *)CPyType_networks___Network;
-    cpy_r_r263 = CPyStatics[267]; /* 'name' */
+    cpy_r_r263 = CPyStatics[269]; /* 'name' */
     PyObject *cpy_r_r264[1] = {cpy_r_r262};
     cpy_r_r265 = (PyObject **)&cpy_r_r264;
     cpy_r_r266 = PyObject_VectorcallMethod(cpy_r_r263, cpy_r_r265, 9223372036854775809ULL, 0);
@@ -17511,7 +17620,7 @@ CPyL20: ;
     CPyStatic_networks___NETWORK_NAME = cpy_r_r267;
     CPy_INCREF(CPyStatic_networks___NETWORK_NAME);
     cpy_r_r268 = CPyStatic_networks___globals;
-    cpy_r_r269 = CPyStatics[282]; /* 'NETWORK_NAME' */
+    cpy_r_r269 = CPyStatics[284]; /* 'NETWORK_NAME' */
     cpy_r_r270 = CPyDict_SetItem(cpy_r_r268, cpy_r_r269, cpy_r_r267);
     CPy_DECREF(cpy_r_r267);
     cpy_r_r271 = cpy_r_r270 >= 0;
@@ -18397,7 +18506,7 @@ CPyL5: ;
     }
     CPy_INCREF(cpy_r_r8);
 CPyL6: ;
-    cpy_r_r9 = CPyStatics[486]; /* 1000 */
+    cpy_r_r9 = CPyStatics[487]; /* 1000 */
     cpy_r_r10 = PyObject_RichCompare(cpy_r_r8, cpy_r_r9, 0);
     CPy_DECREF(cpy_r_r8);
     if (unlikely(cpy_r_r10 == NULL)) {
@@ -18702,13 +18811,13 @@ CPyL57: ;
     CPy_INCREF(cpy_r_r49);
 CPyL58: ;
     cpy_r_r50 = CPyModule_builtins;
-    cpy_r_r51 = CPyStatics[283]; /* 'round' */
+    cpy_r_r51 = CPyStatics[285]; /* 'round' */
     cpy_r_r52 = CPyObject_GetAttr(cpy_r_r50, cpy_r_r51);
     if (unlikely(cpy_r_r52 == NULL)) {
         CPy_AddTraceback("y/prices/utils/sense_check.py", "sense_check", 249, CPyStatic_sense_check___globals);
         goto CPyL160;
     }
-    cpy_r_r53 = CPyStatics[487]; /* 4 */
+    cpy_r_r53 = CPyStatics[488]; /* 4 */
     PyObject *cpy_r_r54[2] = {cpy_r_r49, cpy_r_r53};
     cpy_r_r55 = (PyObject **)&cpy_r_r54;
     cpy_r_r56 = PyObject_Vectorcall(cpy_r_r52, cpy_r_r55, 2, 0);
@@ -18735,7 +18844,7 @@ CPyL58: ;
     CPy_INCREF(cpy_r_r58);
 CPyL62: ;
     cpy_r_r59 = CPyStatic_sense_check___globals;
-    cpy_r_r60 = CPyStatics[284]; /* 'ERC20' */
+    cpy_r_r60 = CPyStatics[286]; /* 'ERC20' */
     cpy_r_r61 = CPyDict_GetItem(cpy_r_r59, cpy_r_r60);
     if (unlikely(cpy_r_r61 == NULL)) {
         CPy_AddTraceback("y/prices/utils/sense_check.py", "sense_check", 251, CPyStatic_sense_check___globals);
@@ -18744,7 +18853,7 @@ CPyL62: ;
     cpy_r_r62 = 1 ? Py_True : Py_False;
     PyObject *cpy_r_r63[2] = {cpy_r_r58, cpy_r_r62};
     cpy_r_r64 = (PyObject **)&cpy_r_r63;
-    cpy_r_r65 = CPyStatics[533]; /* ('asynchronous',) */
+    cpy_r_r65 = CPyStatics[534]; /* ('asynchronous',) */
     cpy_r_r66 = PyObject_Vectorcall(cpy_r_r61, cpy_r_r64, 1, cpy_r_r65);
     CPy_DECREF(cpy_r_r61);
     if (unlikely(cpy_r_r66 == NULL)) {
@@ -18752,7 +18861,7 @@ CPyL62: ;
         goto CPyL162;
     }
     CPy_DECREF(cpy_r_r58);
-    cpy_r_r67 = CPyStatics[286]; /* 'symbol' */
+    cpy_r_r67 = CPyStatics[288]; /* 'symbol' */
     cpy_r_r68 = CPyObject_GetAttr(cpy_r_r66, cpy_r_r67);
     CPy_DECREF(cpy_r_r66);
     if (unlikely(cpy_r_r68 == NULL)) {
@@ -18949,7 +19058,7 @@ CPyL94: ;
 CPyL97: ;
     CPy_Unreachable();
 CPyL98: ;
-    cpy_r_r94 = CPyStatics[287]; /* 'unusually high price ($' */
+    cpy_r_r94 = CPyStatics[289]; /* 'unusually high price ($' */
     cpy_r_r95 = ((y___prices___utils___sense_check___sense_check_envObject *)cpy_r_r4)->_price_readable;
     if (unlikely(cpy_r_r95 == NULL)) {
         CPy_AttributeError("y/prices/utils/sense_check.py", "sense_check", "sense_check_env", "price_readable", 253, CPyStatic_sense_check___globals);
@@ -18963,7 +19072,7 @@ CPyL99: ;
         CPy_AddTraceback("y/prices/utils/sense_check.py", "sense_check", 253, CPyStatic_sense_check___globals);
         goto CPyL111;
     }
-    cpy_r_r97 = CPyStatics[288]; /* ') returned for ' */
+    cpy_r_r97 = CPyStatics[290]; /* ') returned for ' */
     cpy_r_r98 = ((y___prices___utils___sense_check___sense_check_envObject *)cpy_r_r4)->_symbol;
     if (unlikely(cpy_r_r98 == NULL)) {
         CPy_AttributeError("y/prices/utils/sense_check.py", "sense_check", "sense_check_env", "symbol", 253, CPyStatic_sense_check___globals);
@@ -18991,9 +19100,9 @@ CPyL103: ;
         CPy_AddTraceback("y/prices/utils/sense_check.py", "sense_check", 253, CPyStatic_sense_check___globals);
         goto CPyL175;
     }
-    cpy_r_r103 = CPyStatics[289]; /* ' on ' */
+    cpy_r_r103 = CPyStatics[291]; /* ' on ' */
     cpy_r_r104 = CPyStatic_sense_check___globals;
-    cpy_r_r105 = CPyStatics[282]; /* 'NETWORK_NAME' */
+    cpy_r_r105 = CPyStatics[284]; /* 'NETWORK_NAME' */
     cpy_r_r106 = CPyDict_GetItem(cpy_r_r104, cpy_r_r105);
     if (unlikely(cpy_r_r106 == NULL)) {
         CPy_AddTraceback("y/prices/utils/sense_check.py", "sense_check", 253, CPyStatic_sense_check___globals);
@@ -19005,7 +19114,7 @@ CPyL103: ;
         CPy_TypeErrorTraceback("y/prices/utils/sense_check.py", "sense_check", 253, CPyStatic_sense_check___globals, "str", cpy_r_r106);
         goto CPyL176;
     }
-    cpy_r_r108 = CPyStatics[290]; /* ' block ' */
+    cpy_r_r108 = CPyStatics[292]; /* ' block ' */
     cpy_r_r109 = ((y___prices___utils___sense_check___sense_check_envObject *)cpy_r_r4)->_block;
     if (unlikely(cpy_r_r109 == NULL)) {
         CPy_AttributeError("y/prices/utils/sense_check.py", "sense_check", "sense_check_env", "block", 253, CPyStatic_sense_check___globals);
@@ -19019,7 +19128,7 @@ CPyL107: ;
         CPy_AddTraceback("y/prices/utils/sense_check.py", "sense_check", 253, CPyStatic_sense_check___globals);
         goto CPyL177;
     }
-    cpy_r_r111 = CPyStatics[291]; /* ('. This does not necessarily mean that the price is '
+    cpy_r_r111 = CPyStatics[293]; /* ('. This does not necessarily mean that the price is '
                                      'wrong, but you may want to validate the price for '
                                      'yourself before proceeding.') */
     cpy_r_r112 = CPyStr_Build(11, cpy_r_r94, cpy_r_r96, cpy_r_r97, cpy_r_r99, cpy_r_r100, cpy_r_r102, cpy_r_r103, cpy_r_r107, cpy_r_r108, cpy_r_r110, cpy_r_r111);
@@ -19032,7 +19141,7 @@ CPyL107: ;
         CPy_AddTraceback("y/prices/utils/sense_check.py", "sense_check", 253, CPyStatic_sense_check___globals);
         goto CPyL111;
     }
-    cpy_r_r113 = CPyStatics[51]; /* 'warning' */
+    cpy_r_r113 = CPyStatics[54]; /* 'warning' */
     PyObject *cpy_r_r114[2] = {cpy_r_r92, cpy_r_r112};
     cpy_r_r115 = (PyObject **)&cpy_r_r114;
     cpy_r_r116 = PyObject_VectorcallMethod(cpy_r_r113, cpy_r_r115, 9223372036854775810ULL, 0);
@@ -19072,7 +19181,7 @@ CPyL111: ;
 CPyL115: ;
     CPy_Unreachable();
 CPyL116: ;
-    cpy_r_r123 = CPyStatics[287]; /* 'unusually high price ($' */
+    cpy_r_r123 = CPyStatics[289]; /* 'unusually high price ($' */
     cpy_r_r124 = ((y___prices___utils___sense_check___sense_check_envObject *)cpy_r_r4)->_price_readable;
     if (unlikely(cpy_r_r124 == NULL)) {
         CPy_AttributeError("y/prices/utils/sense_check.py", "sense_check", "sense_check_env", "price_readable", 257, CPyStatic_sense_check___globals);
@@ -19086,7 +19195,7 @@ CPyL117: ;
         CPy_AddTraceback("y/prices/utils/sense_check.py", "sense_check", 257, CPyStatic_sense_check___globals);
         goto CPyL131;
     }
-    cpy_r_r126 = CPyStatics[288]; /* ') returned for ' */
+    cpy_r_r126 = CPyStatics[290]; /* ') returned for ' */
     cpy_r_r127 = ((y___prices___utils___sense_check___sense_check_envObject *)cpy_r_r4)->_token_address;
     if (unlikely(cpy_r_r127 == NULL)) {
         CPy_AttributeError("y/prices/utils/sense_check.py", "sense_check", "sense_check_env", "token_address", 257, CPyStatic_sense_check___globals);
@@ -19100,9 +19209,9 @@ CPyL119: ;
         CPy_AddTraceback("y/prices/utils/sense_check.py", "sense_check", 257, CPyStatic_sense_check___globals);
         goto CPyL181;
     }
-    cpy_r_r129 = CPyStatics[289]; /* ' on ' */
+    cpy_r_r129 = CPyStatics[291]; /* ' on ' */
     cpy_r_r130 = CPyStatic_sense_check___globals;
-    cpy_r_r131 = CPyStatics[282]; /* 'NETWORK_NAME' */
+    cpy_r_r131 = CPyStatics[284]; /* 'NETWORK_NAME' */
     cpy_r_r132 = CPyDict_GetItem(cpy_r_r130, cpy_r_r131);
     if (unlikely(cpy_r_r132 == NULL)) {
         CPy_AddTraceback("y/prices/utils/sense_check.py", "sense_check", 257, CPyStatic_sense_check___globals);
@@ -19114,7 +19223,7 @@ CPyL119: ;
         CPy_TypeErrorTraceback("y/prices/utils/sense_check.py", "sense_check", 257, CPyStatic_sense_check___globals, "str", cpy_r_r132);
         goto CPyL182;
     }
-    cpy_r_r134 = CPyStatics[290]; /* ' block ' */
+    cpy_r_r134 = CPyStatics[292]; /* ' block ' */
     cpy_r_r135 = ((y___prices___utils___sense_check___sense_check_envObject *)cpy_r_r4)->_block;
     if (unlikely(cpy_r_r135 == NULL)) {
         CPy_AttributeError("y/prices/utils/sense_check.py", "sense_check", "sense_check_env", "block", 257, CPyStatic_sense_check___globals);
@@ -19128,7 +19237,7 @@ CPyL123: ;
         CPy_AddTraceback("y/prices/utils/sense_check.py", "sense_check", 257, CPyStatic_sense_check___globals);
         goto CPyL183;
     }
-    cpy_r_r137 = CPyStatics[291]; /* ('. This does not necessarily mean that the price is '
+    cpy_r_r137 = CPyStatics[293]; /* ('. This does not necessarily mean that the price is '
                                      'wrong, but you may want to validate the price for '
                                      'yourself before proceeding.') */
     cpy_r_r138 = CPyStr_Build(9, cpy_r_r123, cpy_r_r125, cpy_r_r126, cpy_r_r128, cpy_r_r129, cpy_r_r133, cpy_r_r134, cpy_r_r136, cpy_r_r137);
@@ -19140,7 +19249,7 @@ CPyL123: ;
         CPy_AddTraceback("y/prices/utils/sense_check.py", "sense_check", 257, CPyStatic_sense_check___globals);
         goto CPyL131;
     }
-    cpy_r_r139 = CPyStatics[51]; /* 'warning' */
+    cpy_r_r139 = CPyStatics[54]; /* 'warning' */
     PyObject *cpy_r_r140[2] = {cpy_r_r121, cpy_r_r138};
     cpy_r_r141 = (PyObject **)&cpy_r_r140;
     cpy_r_r142 = PyObject_VectorcallMethod(cpy_r_r139, cpy_r_r141, 9223372036854775810ULL, 0);
@@ -19629,7 +19738,7 @@ PyObject *CPyDef_sense_check___sense_check_gen___close(PyObject *cpy_r___mypyc_s
     char cpy_r_r14;
     PyObject *cpy_r_r15;
     cpy_r_r0 = CPyModule_builtins;
-    cpy_r_r1 = CPyStatics[145]; /* 'GeneratorExit' */
+    cpy_r_r1 = CPyStatics[147]; /* 'GeneratorExit' */
     cpy_r_r2 = CPyObject_GetAttr(cpy_r_r0, cpy_r_r1);
     if (cpy_r_r2 == NULL) goto CPyL3;
     cpy_r_r3 = (PyObject *)&_Py_NoneStruct;
@@ -19639,7 +19748,7 @@ PyObject *CPyDef_sense_check___sense_check_gen___close(PyObject *cpy_r___mypyc_s
 CPyL3: ;
     cpy_r_r6 = CPy_CatchError();
     cpy_r_r7 = CPyModule_builtins;
-    cpy_r_r8 = CPyStatics[146]; /* 'StopIteration' */
+    cpy_r_r8 = CPyStatics[148]; /* 'StopIteration' */
     cpy_r_r9 = CPyObject_GetAttr(cpy_r_r7, cpy_r_r8);
     if (cpy_r_r9 == NULL) goto CPyL12;
     cpy_r_r10.f0 = cpy_r_r2;
@@ -20323,7 +20432,7 @@ CPyL5: ;
     CPy_INCREF(cpy_r_r22);
 CPyL6: ;
     cpy_r_r23 = CPyStatic_sense_check___globals;
-    cpy_r_r24 = CPyStatics[292]; /* 'check_bucket' */
+    cpy_r_r24 = CPyStatics[294]; /* 'check_bucket' */
     cpy_r_r25 = CPyDict_GetItem(cpy_r_r23, cpy_r_r24);
     if (unlikely(cpy_r_r25 == NULL)) {
         CPy_AddTraceback("y/prices/utils/sense_check.py", "_exit_sense_check", 282, CPyStatic_sense_check___globals);
@@ -20332,7 +20441,7 @@ CPyL6: ;
     cpy_r_r26 = 0 ? Py_True : Py_False;
     PyObject *cpy_r_r27[2] = {cpy_r_r22, cpy_r_r26};
     cpy_r_r28 = (PyObject **)&cpy_r_r27;
-    cpy_r_r29 = CPyStatics[534]; /* ('sync',) */
+    cpy_r_r29 = CPyStatics[535]; /* ('sync',) */
     cpy_r_r30 = PyObject_Vectorcall(cpy_r_r25, cpy_r_r28, 1, cpy_r_r29);
     CPy_DECREF(cpy_r_r25);
     if (unlikely(cpy_r_r30 == NULL)) {
@@ -20526,7 +20635,7 @@ CPyL37: ;
     }
     CPy_INCREF(cpy_r_r54);
 CPyL39: ;
-    cpy_r_r55 = CPyStatics[294]; /* 'uni or uni-like lp' */
+    cpy_r_r55 = CPyStatics[296]; /* 'uni or uni-like lp' */
     cpy_r_r56 = PyObject_RichCompare(cpy_r_r54, cpy_r_r55, 2);
     CPy_DECREF(cpy_r_r54);
     if (unlikely(cpy_r_r56 == NULL)) {
@@ -20555,7 +20664,7 @@ CPyL43: ;
     }
     CPy_INCREF(cpy_r_r58);
 CPyL44: ;
-    cpy_r_r59 = CPyStatics[295]; /* 'balancer pool' */
+    cpy_r_r59 = CPyStatics[297]; /* 'balancer pool' */
     cpy_r_r60 = PyObject_RichCompare(cpy_r_r58, cpy_r_r59, 2);
     CPy_DECREF(cpy_r_r58);
     if (unlikely(cpy_r_r60 == NULL)) {
@@ -20598,7 +20707,7 @@ CPyL50: ;
     }
     CPy_INCREF(cpy_r_r64);
 CPyL51: ;
-    cpy_r_r65 = CPyStatics[296]; /* 'curve lp' */
+    cpy_r_r65 = CPyStatics[298]; /* 'curve lp' */
     cpy_r_r66 = PyObject_RichCompare(cpy_r_r64, cpy_r_r65, 2);
     CPy_DECREF(cpy_r_r64);
     if (unlikely(cpy_r_r66 == NULL)) {
@@ -20626,7 +20735,7 @@ CPyL54: ;
     CPy_INCREF(cpy_r_r70);
 CPyL55: ;
     cpy_r_r71 = CPyStatic_sense_check___globals;
-    cpy_r_r72 = CPyStatics[297]; /* 'CurvePool' */
+    cpy_r_r72 = CPyStatics[299]; /* 'CurvePool' */
     cpy_r_r73 = CPyDict_GetItem(cpy_r_r71, cpy_r_r72);
     if (unlikely(cpy_r_r73 == NULL)) {
         CPy_AddTraceback("y/prices/utils/sense_check.py", "_exit_sense_check", 288, CPyStatic_sense_check___globals);
@@ -20635,7 +20744,7 @@ CPyL55: ;
     cpy_r_r74 = 1 ? Py_True : Py_False;
     PyObject *cpy_r_r75[2] = {cpy_r_r70, cpy_r_r74};
     cpy_r_r76 = (PyObject **)&cpy_r_r75;
-    cpy_r_r77 = CPyStatics[533]; /* ('asynchronous',) */
+    cpy_r_r77 = CPyStatics[534]; /* ('asynchronous',) */
     cpy_r_r78 = PyObject_Vectorcall(cpy_r_r73, cpy_r_r76, 1, cpy_r_r77);
     CPy_DECREF(cpy_r_r73);
     if (unlikely(cpy_r_r78 == NULL)) {
@@ -20643,7 +20752,7 @@ CPyL55: ;
         goto CPyL416;
     }
     CPy_DECREF(cpy_r_r70);
-    cpy_r_r79 = CPyStatics[298]; /* 'coins' */
+    cpy_r_r79 = CPyStatics[300]; /* 'coins' */
     cpy_r_r80 = CPyObject_GetAttr(cpy_r_r78, cpy_r_r79);
     CPy_DECREF(cpy_r_r78);
     if (unlikely(cpy_r_r80 == NULL)) {
@@ -20900,7 +21009,7 @@ CPyL95: ;
     }
     CPy_INCREF(cpy_r_r113);
 CPyL98: ;
-    cpy_r_r114 = CPyStatics[178]; /* 'address' */
+    cpy_r_r114 = CPyStatics[180]; /* 'address' */
     cpy_r_r115 = CPyObject_GetAttr(cpy_r_r113, cpy_r_r114);
     CPy_DECREF(cpy_r_r113);
     if (unlikely(cpy_r_r115 == NULL)) {
@@ -20938,7 +21047,7 @@ CPyL102: ;
     }
     CPy_INCREF(cpy_r_r122);
 CPyL105: ;
-    cpy_r_r123 = CPyStatics[178]; /* 'address' */
+    cpy_r_r123 = CPyStatics[180]; /* 'address' */
     cpy_r_r124 = CPyObject_GetAttr(cpy_r_r122, cpy_r_r123);
     CPy_DECREF(cpy_r_r122);
     if (unlikely(cpy_r_r124 == NULL)) {
@@ -20991,7 +21100,7 @@ CPyL110: ;
     cpy_r_r134 = cpy_r_r133 != 0;
     if (!cpy_r_r134) goto CPyL432;
     cpy_r_r135 = CPyStatic_sense_check___globals;
-    cpy_r_r136 = CPyStatics[299]; /* '_exit_sense_check' */
+    cpy_r_r136 = CPyStatics[301]; /* '_exit_sense_check' */
     cpy_r_r137 = CPyDict_GetItem(cpy_r_r135, cpy_r_r136);
     if (unlikely(cpy_r_r137 == NULL)) {
         CPy_AddTraceback("y/prices/utils/sense_check.py", "_exit_sense_check", 292, CPyStatic_sense_check___globals);
@@ -21005,7 +21114,7 @@ CPyL110: ;
     CPy_INCREF_NO_IMM(cpy_r_r138);
 CPyL114: ;
     cpy_r_r139 = CPyModule_a_sync;
-    cpy_r_r140 = CPyStatics[300]; /* 'map' */
+    cpy_r_r140 = CPyStatics[302]; /* 'map' */
     cpy_r_r141 = CPyObject_GetAttr(cpy_r_r139, cpy_r_r140);
     if (unlikely(cpy_r_r141 == NULL)) {
         CPy_AddTraceback("y/prices/utils/sense_check.py", "_exit_sense_check", 292, CPyStatic_sense_check___globals);
@@ -21027,11 +21136,11 @@ CPyL114: ;
         CPy_TypeErrorTraceback("y/prices/utils/sense_check.py", "_exit_sense_check", 292, CPyStatic_sense_check___globals, "dict", cpy_r_r144);
         goto CPyL418;
     }
-    cpy_r_r146 = CPyStatics[301]; /* 'all' */
+    cpy_r_r146 = CPyStatics[303]; /* 'all' */
     cpy_r_r147 = 0 ? Py_True : Py_False;
     PyObject *cpy_r_r148[2] = {cpy_r_r145, cpy_r_r147};
     cpy_r_r149 = (PyObject **)&cpy_r_r148;
-    cpy_r_r150 = CPyStatics[534]; /* ('sync',) */
+    cpy_r_r150 = CPyStatics[535]; /* ('sync',) */
     cpy_r_r151 = PyObject_VectorcallMethod(cpy_r_r146, cpy_r_r149, 9223372036854775809ULL, cpy_r_r150);
     if (unlikely(cpy_r_r151 == NULL)) {
         CPy_AddTraceback("y/prices/utils/sense_check.py", "_exit_sense_check", 292, CPyStatic_sense_check___globals);
@@ -21245,7 +21354,7 @@ CPyL153: ;
     }
     CPy_INCREF(cpy_r_r177);
 CPyL154: ;
-    cpy_r_r178 = CPyStatics[302]; /* 'atoken' */
+    cpy_r_r178 = CPyStatics[304]; /* 'atoken' */
     cpy_r_r179 = PyObject_RichCompare(cpy_r_r177, cpy_r_r178, 2);
     CPy_DECREF(cpy_r_r177);
     if (unlikely(cpy_r_r179 == NULL)) {
@@ -21266,7 +21375,7 @@ CPyL154: ;
         goto CPyL449;
 CPyL157: ;
     cpy_r_r183 = CPyStatic_sense_check___globals;
-    cpy_r_r184 = CPyStatics[303]; /* 'aave' */
+    cpy_r_r184 = CPyStatics[305]; /* 'aave' */
     cpy_r_r185 = CPyDict_GetItem(cpy_r_r183, cpy_r_r184);
     if (unlikely(cpy_r_r185 == NULL)) {
         CPy_AddTraceback("y/prices/utils/sense_check.py", "_exit_sense_check", 298, CPyStatic_sense_check___globals);
@@ -21279,11 +21388,11 @@ CPyL157: ;
     }
     CPy_INCREF(cpy_r_r186);
 CPyL159: ;
-    cpy_r_r187 = CPyStatics[304]; /* 'underlying' */
+    cpy_r_r187 = CPyStatics[306]; /* 'underlying' */
     cpy_r_r188 = 0 ? Py_True : Py_False;
     PyObject *cpy_r_r189[3] = {cpy_r_r185, cpy_r_r186, cpy_r_r188};
     cpy_r_r190 = (PyObject **)&cpy_r_r189;
-    cpy_r_r191 = CPyStatics[534]; /* ('sync',) */
+    cpy_r_r191 = CPyStatics[535]; /* ('sync',) */
     cpy_r_r192 = PyObject_VectorcallMethod(cpy_r_r187, cpy_r_r190, 9223372036854775810ULL, cpy_r_r191);
     if (unlikely(cpy_r_r192 == NULL)) {
         CPy_AddTraceback("y/prices/utils/sense_check.py", "_exit_sense_check", 298, CPyStatic_sense_check___globals);
@@ -21479,7 +21588,7 @@ CPyL190: ;
     }
     CPy_INCREF(cpy_r_r216);
 CPyL191: ;
-    cpy_r_r217 = CPyStatics[305]; /* 'compound' */
+    cpy_r_r217 = CPyStatics[307]; /* 'compound' */
     cpy_r_r218 = PyObject_RichCompare(cpy_r_r216, cpy_r_r217, 2);
     CPy_DECREF(cpy_r_r216);
     if (unlikely(cpy_r_r218 == NULL)) {
@@ -21507,7 +21616,7 @@ CPyL194: ;
     CPy_INCREF(cpy_r_r222);
 CPyL195: ;
     cpy_r_r223 = CPyStatic_sense_check___globals;
-    cpy_r_r224 = CPyStatics[306]; /* 'CToken' */
+    cpy_r_r224 = CPyStatics[308]; /* 'CToken' */
     cpy_r_r225 = CPyDict_GetItem(cpy_r_r223, cpy_r_r224);
     if (unlikely(cpy_r_r225 == NULL)) {
         CPy_AddTraceback("y/prices/utils/sense_check.py", "_exit_sense_check", 300, CPyStatic_sense_check___globals);
@@ -21516,7 +21625,7 @@ CPyL195: ;
     cpy_r_r226 = 1 ? Py_True : Py_False;
     PyObject *cpy_r_r227[2] = {cpy_r_r222, cpy_r_r226};
     cpy_r_r228 = (PyObject **)&cpy_r_r227;
-    cpy_r_r229 = CPyStatics[533]; /* ('asynchronous',) */
+    cpy_r_r229 = CPyStatics[534]; /* ('asynchronous',) */
     cpy_r_r230 = PyObject_Vectorcall(cpy_r_r225, cpy_r_r228, 1, cpy_r_r229);
     CPy_DECREF(cpy_r_r225);
     if (unlikely(cpy_r_r230 == NULL)) {
@@ -21524,7 +21633,7 @@ CPyL195: ;
         goto CPyL467;
     }
     CPy_DECREF(cpy_r_r222);
-    cpy_r_r231 = CPyStatics[304]; /* 'underlying' */
+    cpy_r_r231 = CPyStatics[306]; /* 'underlying' */
     cpy_r_r232 = CPyObject_GetAttr(cpy_r_r230, cpy_r_r231);
     CPy_DECREF(cpy_r_r230);
     if (unlikely(cpy_r_r232 == NULL)) {
@@ -21719,7 +21828,7 @@ CPyL228: ;
     }
     CPy_INCREF(cpy_r_r256);
 CPyL229: ;
-    cpy_r_r257 = CPyStatics[307]; /* 'solidex' */
+    cpy_r_r257 = CPyStatics[309]; /* 'solidex' */
     cpy_r_r258 = PyObject_RichCompare(cpy_r_r256, cpy_r_r257, 2);
     CPy_DECREF(cpy_r_r256);
     if (unlikely(cpy_r_r258 == NULL)) {
@@ -21740,7 +21849,7 @@ CPyL229: ;
         goto CPyL479;
 CPyL232: ;
     cpy_r_r262 = CPyStatic_sense_check___globals;
-    cpy_r_r263 = CPyStatics[210]; /* 'Contract' */
+    cpy_r_r263 = CPyStatics[212]; /* 'Contract' */
     cpy_r_r264 = CPyDict_GetItem(cpy_r_r262, cpy_r_r263);
     if (unlikely(cpy_r_r264 == NULL)) {
         CPy_AddTraceback("y/prices/utils/sense_check.py", "_exit_sense_check", 302, CPyStatic_sense_check___globals);
@@ -21753,7 +21862,7 @@ CPyL232: ;
     }
     CPy_INCREF(cpy_r_r265);
 CPyL234: ;
-    cpy_r_r266 = CPyStatics[308]; /* 'coroutine' */
+    cpy_r_r266 = CPyStatics[310]; /* 'coroutine' */
     PyObject *cpy_r_r267[2] = {cpy_r_r264, cpy_r_r265};
     cpy_r_r268 = (PyObject **)&cpy_r_r267;
     cpy_r_r269 = PyObject_VectorcallMethod(cpy_r_r266, cpy_r_r268, 9223372036854775810ULL, 0);
@@ -21955,7 +22064,7 @@ CPyL264: ;
     }
     CPy_INCREF_NO_IMM(cpy_r_r294);
 CPyL267: ;
-    cpy_r_r295 = CPyStatics[309]; /* 'pool' */
+    cpy_r_r295 = CPyStatics[311]; /* 'pool' */
     cpy_r_r296 = CPyObject_GetAttr(cpy_r_r294, cpy_r_r295);
     CPy_DECREF_NO_IMM(cpy_r_r294);
     if (unlikely(cpy_r_r296 == NULL)) {
@@ -22150,7 +22259,7 @@ CPyL298: ;
     }
     CPy_INCREF(cpy_r_r320);
 CPyL299: ;
-    cpy_r_r321 = CPyStatics[310]; /* 'yearn or yearn-like' */
+    cpy_r_r321 = CPyStatics[312]; /* 'yearn or yearn-like' */
     cpy_r_r322 = PyObject_RichCompare(cpy_r_r320, cpy_r_r321, 2);
     CPy_DECREF(cpy_r_r320);
     if (unlikely(cpy_r_r322 == NULL)) {
@@ -22174,7 +22283,7 @@ CPyL299: ;
     CPy_INCREF(cpy_r_r326);
 CPyL303: ;
     cpy_r_r327 = CPyStatic_sense_check___globals;
-    cpy_r_r328 = CPyStatics[311]; /* 'YearnInspiredVault' */
+    cpy_r_r328 = CPyStatics[313]; /* 'YearnInspiredVault' */
     cpy_r_r329 = CPyDict_GetItem(cpy_r_r327, cpy_r_r328);
     if (unlikely(cpy_r_r329 == NULL)) {
         CPy_AddTraceback("y/prices/utils/sense_check.py", "_exit_sense_check", 305, CPyStatic_sense_check___globals);
@@ -22183,7 +22292,7 @@ CPyL303: ;
     cpy_r_r330 = 1 ? Py_True : Py_False;
     PyObject *cpy_r_r331[2] = {cpy_r_r326, cpy_r_r330};
     cpy_r_r332 = (PyObject **)&cpy_r_r331;
-    cpy_r_r333 = CPyStatics[533]; /* ('asynchronous',) */
+    cpy_r_r333 = CPyStatics[534]; /* ('asynchronous',) */
     cpy_r_r334 = PyObject_Vectorcall(cpy_r_r329, cpy_r_r332, 1, cpy_r_r333);
     CPy_DECREF(cpy_r_r329);
     if (unlikely(cpy_r_r334 == NULL)) {
@@ -22191,7 +22300,7 @@ CPyL303: ;
         goto CPyL504;
     }
     CPy_DECREF(cpy_r_r326);
-    cpy_r_r335 = CPyStatics[304]; /* 'underlying' */
+    cpy_r_r335 = CPyStatics[306]; /* 'underlying' */
     cpy_r_r336 = CPyObject_GetAttr(cpy_r_r334, cpy_r_r335);
     CPy_DECREF(cpy_r_r334);
     if (unlikely(cpy_r_r336 == NULL)) {
@@ -22401,7 +22510,7 @@ CPyL339: ;
     }
     CPy_INCREF(cpy_r_r362);
 CPyL340: ;
-    cpy_r_r363 = CPyStatics[178]; /* 'address' */
+    cpy_r_r363 = CPyStatics[180]; /* 'address' */
     cpy_r_r364 = CPyObject_GetAttr(cpy_r_r362, cpy_r_r363);
     CPy_DECREF(cpy_r_r362);
     if (unlikely(cpy_r_r364 == NULL)) {
@@ -23665,7 +23774,7 @@ PyObject *CPyDef_sense_check____exit_sense_check_gen___close(PyObject *cpy_r___m
     char cpy_r_r14;
     PyObject *cpy_r_r15;
     cpy_r_r0 = CPyModule_builtins;
-    cpy_r_r1 = CPyStatics[145]; /* 'GeneratorExit' */
+    cpy_r_r1 = CPyStatics[147]; /* 'GeneratorExit' */
     cpy_r_r2 = CPyObject_GetAttr(cpy_r_r0, cpy_r_r1);
     if (cpy_r_r2 == NULL) goto CPyL3;
     cpy_r_r3 = (PyObject *)&_Py_NoneStruct;
@@ -23675,7 +23784,7 @@ PyObject *CPyDef_sense_check____exit_sense_check_gen___close(PyObject *cpy_r___m
 CPyL3: ;
     cpy_r_r6 = CPy_CatchError();
     cpy_r_r7 = CPyModule_builtins;
-    cpy_r_r8 = CPyStatics[146]; /* 'StopIteration' */
+    cpy_r_r8 = CPyStatics[148]; /* 'StopIteration' */
     cpy_r_r9 = CPyObject_GetAttr(cpy_r_r7, cpy_r_r8);
     if (cpy_r_r9 == NULL) goto CPyL12;
     cpy_r_r10.f0 = cpy_r_r2;
@@ -24403,14 +24512,14 @@ CPyL3: ;
     cpy_r_r7 = (void *)&cpy_r_r6;
     int64_t cpy_r_r8[1] = {12};
     cpy_r_r9 = (void *)&cpy_r_r8;
-    cpy_r_r10 = CPyStatics[523]; /* (('logging', 'logging', 'logging'),) */
+    cpy_r_r10 = CPyStatics[524]; /* (('logging', 'logging', 'logging'),) */
     cpy_r_r11 = CPyStatic_sense_check___globals;
-    cpy_r_r12 = CPyStatics[312]; /* 'y/prices/utils/sense_check.py' */
+    cpy_r_r12 = CPyStatics[314]; /* 'y/prices/utils/sense_check.py' */
     cpy_r_r13 = CPyStatics[31]; /* '<module>' */
     cpy_r_r14 = CPyImport_ImportMany(cpy_r_r10, cpy_r_r7, cpy_r_r11, cpy_r_r12, cpy_r_r13, cpy_r_r9);
     if (!cpy_r_r14) goto CPyL202;
-    cpy_r_r15 = CPyStatics[501]; /* ('Decimal',) */
-    cpy_r_r16 = CPyStatics[86]; /* 'decimal' */
+    cpy_r_r15 = CPyStatics[504]; /* ('Decimal',) */
+    cpy_r_r16 = CPyStatics[91]; /* 'decimal' */
     cpy_r_r17 = CPyStatic_sense_check___globals;
     cpy_r_r18 = CPyImport_ImportFromMany(cpy_r_r16, cpy_r_r15, cpy_r_r15, cpy_r_r17);
     if (unlikely(cpy_r_r18 == NULL)) {
@@ -24420,7 +24529,7 @@ CPyL3: ;
     CPyModule_decimal = cpy_r_r18;
     CPy_INCREF(CPyModule_decimal);
     CPy_DECREF(cpy_r_r18);
-    cpy_r_r19 = CPyStatics[535]; /* ('Final', 'Optional', 'Set', 'Union') */
+    cpy_r_r19 = CPyStatics[536]; /* ('Final', 'Optional', 'Set', 'Union') */
     cpy_r_r20 = CPyStatics[37]; /* 'typing' */
     cpy_r_r21 = CPyStatic_sense_check___globals;
     cpy_r_r22 = CPyImport_ImportFromMany(cpy_r_r20, cpy_r_r19, cpy_r_r19, cpy_r_r21);
@@ -24436,14 +24545,14 @@ CPyL3: ;
     cpy_r_r25 = (void *)&cpy_r_r24;
     int64_t cpy_r_r26[1] = {16};
     cpy_r_r27 = (void *)&cpy_r_r26;
-    cpy_r_r28 = CPyStatics[536]; /* (('a_sync', 'a_sync', 'a_sync'),) */
+    cpy_r_r28 = CPyStatics[537]; /* (('a_sync', 'a_sync', 'a_sync'),) */
     cpy_r_r29 = CPyStatic_sense_check___globals;
-    cpy_r_r30 = CPyStatics[312]; /* 'y/prices/utils/sense_check.py' */
+    cpy_r_r30 = CPyStatics[314]; /* 'y/prices/utils/sense_check.py' */
     cpy_r_r31 = CPyStatics[31]; /* '<module>' */
     cpy_r_r32 = CPyImport_ImportMany(cpy_r_r28, cpy_r_r25, cpy_r_r29, cpy_r_r30, cpy_r_r31, cpy_r_r27);
     if (!cpy_r_r32) goto CPyL202;
-    cpy_r_r33 = CPyStatics[529]; /* ('BlockNumber', 'ChecksumAddress') */
-    cpy_r_r34 = CPyStatics[159]; /* 'eth_typing' */
+    cpy_r_r33 = CPyStatics[530]; /* ('BlockNumber', 'ChecksumAddress') */
+    cpy_r_r34 = CPyStatics[161]; /* 'eth_typing' */
     cpy_r_r35 = CPyStatic_sense_check___globals;
     cpy_r_r36 = CPyImport_ImportFromMany(cpy_r_r34, cpy_r_r33, cpy_r_r33, cpy_r_r35);
     if (unlikely(cpy_r_r36 == NULL)) {
@@ -24453,8 +24562,8 @@ CPyL3: ;
     CPyModule_eth_typing = cpy_r_r36;
     CPy_INCREF(CPyModule_eth_typing);
     CPy_DECREF(cpy_r_r36);
-    cpy_r_r37 = CPyStatics[537]; /* ('ERC20',) */
-    cpy_r_r38 = CPyStatics[314]; /* 'y.classes.common' */
+    cpy_r_r37 = CPyStatics[538]; /* ('ERC20',) */
+    cpy_r_r38 = CPyStatics[316]; /* 'y.classes.common' */
     cpy_r_r39 = CPyStatic_sense_check___globals;
     cpy_r_r40 = CPyImport_ImportFromMany(cpy_r_r38, cpy_r_r37, cpy_r_r37, cpy_r_r39);
     if (unlikely(cpy_r_r40 == NULL)) {
@@ -24464,8 +24573,8 @@ CPyL3: ;
     CPyModule_y___classes___common = cpy_r_r40;
     CPy_INCREF(CPyModule_y___classes___common);
     CPy_DECREF(cpy_r_r40);
-    cpy_r_r41 = CPyStatics[538]; /* ('CHAINID', 'NETWORK_NAME', 'wbtc', 'weth') */
-    cpy_r_r42 = CPyStatics[317]; /* 'y.constants' */
+    cpy_r_r41 = CPyStatics[539]; /* ('CHAINID', 'NETWORK_NAME', 'wbtc', 'weth') */
+    cpy_r_r42 = CPyStatics[319]; /* 'y.constants' */
     cpy_r_r43 = CPyStatic_sense_check___globals;
     cpy_r_r44 = CPyImport_ImportFromMany(cpy_r_r42, cpy_r_r41, cpy_r_r41, cpy_r_r43);
     if (unlikely(cpy_r_r44 == NULL)) {
@@ -24475,8 +24584,8 @@ CPyL3: ;
     CPyModule_y___constants = cpy_r_r44;
     CPy_INCREF(CPyModule_y___constants);
     CPy_DECREF(cpy_r_r44);
-    cpy_r_r45 = CPyStatics[526]; /* ('Contract',) */
-    cpy_r_r46 = CPyStatics[318]; /* 'y.contracts' */
+    cpy_r_r45 = CPyStatics[527]; /* ('Contract',) */
+    cpy_r_r46 = CPyStatics[320]; /* 'y.contracts' */
     cpy_r_r47 = CPyStatic_sense_check___globals;
     cpy_r_r48 = CPyImport_ImportFromMany(cpy_r_r46, cpy_r_r45, cpy_r_r45, cpy_r_r47);
     if (unlikely(cpy_r_r48 == NULL)) {
@@ -24486,8 +24595,8 @@ CPyL3: ;
     CPyModule_y___contracts = cpy_r_r48;
     CPy_INCREF(CPyModule_y___contracts);
     CPy_DECREF(cpy_r_r48);
-    cpy_r_r49 = CPyStatics[539]; /* ('NonStandardERC20',) */
-    cpy_r_r50 = CPyStatics[214]; /* 'y.exceptions' */
+    cpy_r_r49 = CPyStatics[540]; /* ('NonStandardERC20',) */
+    cpy_r_r50 = CPyStatics[216]; /* 'y.exceptions' */
     cpy_r_r51 = CPyStatic_sense_check___globals;
     cpy_r_r52 = CPyImport_ImportFromMany(cpy_r_r50, cpy_r_r49, cpy_r_r49, cpy_r_r51);
     if (unlikely(cpy_r_r52 == NULL)) {
@@ -24497,8 +24606,8 @@ CPyL3: ;
     CPyModule_y___exceptions = cpy_r_r52;
     CPy_INCREF(CPyModule_y___exceptions);
     CPy_DECREF(cpy_r_r52);
-    cpy_r_r53 = CPyStatics[521]; /* ('Network',) */
-    cpy_r_r54 = CPyStatics[281]; /* 'y.networks' */
+    cpy_r_r53 = CPyStatics[522]; /* ('Network',) */
+    cpy_r_r54 = CPyStatics[283]; /* 'y.networks' */
     cpy_r_r55 = CPyStatic_sense_check___globals;
     cpy_r_r56 = CPyImport_ImportFromMany(cpy_r_r54, cpy_r_r53, cpy_r_r53, cpy_r_r55);
     if (unlikely(cpy_r_r56 == NULL)) {
@@ -24508,8 +24617,8 @@ CPyL3: ;
     CPyModule_y___networks = cpy_r_r56;
     CPy_INCREF(CPyModule_y___networks);
     CPy_DECREF(cpy_r_r56);
-    cpy_r_r57 = CPyStatics[540]; /* ('aave',) */
-    cpy_r_r58 = CPyStatics[319]; /* 'y.prices.lending.aave' */
+    cpy_r_r57 = CPyStatics[541]; /* ('aave',) */
+    cpy_r_r58 = CPyStatics[321]; /* 'y.prices.lending.aave' */
     cpy_r_r59 = CPyStatic_sense_check___globals;
     cpy_r_r60 = CPyImport_ImportFromMany(cpy_r_r58, cpy_r_r57, cpy_r_r57, cpy_r_r59);
     if (unlikely(cpy_r_r60 == NULL)) {
@@ -24519,8 +24628,8 @@ CPyL3: ;
     CPyModule_y___prices___lending___aave = cpy_r_r60;
     CPy_INCREF(CPyModule_y___prices___lending___aave);
     CPy_DECREF(cpy_r_r60);
-    cpy_r_r61 = CPyStatics[541]; /* ('CToken',) */
-    cpy_r_r62 = CPyStatics[320]; /* 'y.prices.lending.compound' */
+    cpy_r_r61 = CPyStatics[542]; /* ('CToken',) */
+    cpy_r_r62 = CPyStatics[322]; /* 'y.prices.lending.compound' */
     cpy_r_r63 = CPyStatic_sense_check___globals;
     cpy_r_r64 = CPyImport_ImportFromMany(cpy_r_r62, cpy_r_r61, cpy_r_r61, cpy_r_r63);
     if (unlikely(cpy_r_r64 == NULL)) {
@@ -24530,8 +24639,8 @@ CPyL3: ;
     CPyModule_y___prices___lending___compound = cpy_r_r64;
     CPy_INCREF(CPyModule_y___prices___lending___compound);
     CPy_DECREF(cpy_r_r64);
-    cpy_r_r65 = CPyStatics[542]; /* ('CurvePool',) */
-    cpy_r_r66 = CPyStatics[321]; /* 'y.prices.stable_swap.curve' */
+    cpy_r_r65 = CPyStatics[543]; /* ('CurvePool',) */
+    cpy_r_r66 = CPyStatics[323]; /* 'y.prices.stable_swap.curve' */
     cpy_r_r67 = CPyStatic_sense_check___globals;
     cpy_r_r68 = CPyImport_ImportFromMany(cpy_r_r66, cpy_r_r65, cpy_r_r65, cpy_r_r67);
     if (unlikely(cpy_r_r68 == NULL)) {
@@ -24541,8 +24650,8 @@ CPyL3: ;
     CPyModule_y___prices___stable_swap___curve = cpy_r_r68;
     CPy_INCREF(CPyModule_y___prices___stable_swap___curve);
     CPy_DECREF(cpy_r_r68);
-    cpy_r_r69 = CPyStatics[543]; /* ('check_bucket',) */
-    cpy_r_r70 = CPyStatics[322]; /* 'y.prices.utils' */
+    cpy_r_r69 = CPyStatics[544]; /* ('check_bucket',) */
+    cpy_r_r70 = CPyStatics[324]; /* 'y.prices.utils' */
     cpy_r_r71 = CPyStatic_sense_check___globals;
     cpy_r_r72 = CPyImport_ImportFromMany(cpy_r_r70, cpy_r_r69, cpy_r_r69, cpy_r_r71);
     if (unlikely(cpy_r_r72 == NULL)) {
@@ -24552,8 +24661,8 @@ CPyL3: ;
     CPyModule_y___prices___utils = cpy_r_r72;
     CPy_INCREF(CPyModule_y___prices___utils);
     CPy_DECREF(cpy_r_r72);
-    cpy_r_r73 = CPyStatics[544]; /* ('YearnInspiredVault',) */
-    cpy_r_r74 = CPyStatics[323]; /* 'y.prices.yearn' */
+    cpy_r_r73 = CPyStatics[545]; /* ('YearnInspiredVault',) */
+    cpy_r_r74 = CPyStatics[325]; /* 'y.prices.yearn' */
     cpy_r_r75 = CPyStatic_sense_check___globals;
     cpy_r_r76 = CPyImport_ImportFromMany(cpy_r_r74, cpy_r_r73, cpy_r_r73, cpy_r_r75);
     if (unlikely(cpy_r_r76 == NULL)) {
@@ -24577,7 +24686,7 @@ CPyL3: ;
         goto CPyL202;
     }
     cpy_r_r81 = CPyModule_logging;
-    cpy_r_r82 = CPyStatics[49]; /* 'getLogger' */
+    cpy_r_r82 = CPyStatics[52]; /* 'getLogger' */
     cpy_r_r83 = CPyObject_GetAttr(cpy_r_r81, cpy_r_r82);
     if (unlikely(cpy_r_r83 == NULL)) {
         CPy_AddTraceback("y/prices/utils/sense_check.py", "<module>", 30, CPyStatic_sense_check___globals);
@@ -24595,7 +24704,7 @@ CPyL3: ;
     CPyStatic_sense_check___logger = cpy_r_r86;
     CPy_INCREF(CPyStatic_sense_check___logger);
     cpy_r_r87 = CPyStatic_sense_check___globals;
-    cpy_r_r88 = CPyStatics[50]; /* 'logger' */
+    cpy_r_r88 = CPyStatics[53]; /* 'logger' */
     cpy_r_r89 = CPyDict_SetItem(cpy_r_r87, cpy_r_r88, cpy_r_r86);
     CPy_DECREF(cpy_r_r86);
     cpy_r_r90 = cpy_r_r89 >= 0;
@@ -24604,13 +24713,13 @@ CPyL3: ;
         goto CPyL202;
     }
     cpy_r_r91 = CPyStatic_sense_check___globals;
-    cpy_r_r92 = CPyStatics[316]; /* 'weth' */
+    cpy_r_r92 = CPyStatics[318]; /* 'weth' */
     cpy_r_r93 = CPyDict_GetItem(cpy_r_r91, cpy_r_r92);
     if (unlikely(cpy_r_r93 == NULL)) {
         CPy_AddTraceback("y/prices/utils/sense_check.py", "<module>", 35, CPyStatic_sense_check___globals);
         goto CPyL202;
     }
-    cpy_r_r94 = CPyStatics[178]; /* 'address' */
+    cpy_r_r94 = CPyStatics[180]; /* 'address' */
     cpy_r_r95 = CPyObject_GetAttr(cpy_r_r93, cpy_r_r94);
     CPy_DECREF(cpy_r_r93);
     if (unlikely(cpy_r_r95 == NULL)) {
@@ -24624,13 +24733,13 @@ CPyL3: ;
         goto CPyL202;
     }
     cpy_r_r97 = CPyStatic_sense_check___globals;
-    cpy_r_r98 = CPyStatics[315]; /* 'wbtc' */
+    cpy_r_r98 = CPyStatics[317]; /* 'wbtc' */
     cpy_r_r99 = CPyDict_GetItem(cpy_r_r97, cpy_r_r98);
     if (unlikely(cpy_r_r99 == NULL)) {
         CPy_AddTraceback("y/prices/utils/sense_check.py", "<module>", 36, CPyStatic_sense_check___globals);
         goto CPyL204;
     }
-    cpy_r_r100 = CPyStatics[178]; /* 'address' */
+    cpy_r_r100 = CPyStatics[180]; /* 'address' */
     cpy_r_r101 = CPyObject_GetAttr(cpy_r_r99, cpy_r_r100);
     CPy_DECREF(cpy_r_r99);
     if (unlikely(cpy_r_r101 == NULL)) {
@@ -24665,7 +24774,7 @@ CPyL3: ;
     CPyStatic_sense_check___acceptable_all_chains = cpy_r_r103;
     CPy_INCREF(CPyStatic_sense_check___acceptable_all_chains);
     cpy_r_r108 = CPyStatic_sense_check___globals;
-    cpy_r_r109 = CPyStatics[324]; /* 'acceptable_all_chains' */
+    cpy_r_r109 = CPyStatics[326]; /* 'acceptable_all_chains' */
     cpy_r_r110 = CPyDict_SetItem(cpy_r_r108, cpy_r_r109, cpy_r_r103);
     CPy_DECREF(cpy_r_r103);
     cpy_r_r111 = cpy_r_r110 >= 0;
@@ -24683,103 +24792,103 @@ CPyL3: ;
     }
     CPy_Unreachable();
 CPyL36: ;
-    cpy_r_r114 = CPyStatics[325]; /* '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE' */
-    cpy_r_r115 = CPyStatics[326]; /* '0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0' */
-    cpy_r_r116 = CPyStatics[327]; /* '0xA3D87FffcE63B53E0d54fAa1cc983B7eB0b74A9c' */
-    cpy_r_r117 = CPyStatics[328]; /* '0xaA17A236F2bAdc98DDc0Cf999AbB47D47Fc0A6Cf' */
-    cpy_r_r118 = CPyStatics[329]; /* '0x53a901d48795C58f485cBB38df08FA96a24669D5' */
-    cpy_r_r119 = CPyStatics[330]; /* '0xC4C319E2D4d66CcA4464C0c2B32c9Bd23ebe784e' */
-    cpy_r_r120 = CPyStatics[331]; /* '0x06325440D014e39736583c165C2963BA99fAf14E' */
-    cpy_r_r121 = CPyStatics[332]; /* '0x5e74C9036fb86BD7eCdcb084a0673EFc32eA31cb' */
-    cpy_r_r122 = CPyStatics[333]; /* '0xae78736Cd615f374D3085123A210448E74Fc6393' */
-    cpy_r_r123 = CPyStatics[334]; /* '0xE95A203B1a91a908F9B9CE46459d101078c2c3cb' */
-    cpy_r_r124 = CPyStatics[335]; /* '0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84' */
-    cpy_r_r125 = CPyStatics[336]; /* '0x9559Aaa82d9649C7A7b220E7c461d2E74c9a3593' */
-    cpy_r_r126 = CPyStatics[337]; /* '0x836A808d4828586A69364065A1e064609F5078c7' */
-    cpy_r_r127 = CPyStatics[338]; /* '0xc3D088842DcF02C13699F936BB83DFBBc6f721Ab' */
-    cpy_r_r128 = CPyStatics[339]; /* '0xC1330aCBbcE97cb9695B7ee161c0F95B875a8b0F' */
-    cpy_r_r129 = CPyStatics[340]; /* '0x5E8422345238F34275888049021821E8E08CAa1f' */
-    cpy_r_r130 = CPyStatics[341]; /* '0x856c4Efb76C1D1AE02e20CEB03A2A6a08b0b8dC3' */
-    cpy_r_r131 = CPyStatics[342]; /* '0xE72B141DF173b999AE7c1aDcbF60Cc9833Ce56a8' */
-    cpy_r_r132 = CPyStatics[343]; /* '0x3d1E5Cf16077F349e999d6b21A4f646e83Cd90c5' */
-    cpy_r_r133 = CPyStatics[344]; /* '0x0100546F2cD4C9D97f798fFC9755E47865FF7Ee6' */
-    cpy_r_r134 = CPyStatics[345]; /* '0xBe9895146f7AF43049ca1c1AE358B0541Ea49704' */
-    cpy_r_r135 = CPyStatics[346]; /* '0x7C07F7aBe10CE8e33DC6C5aD68FE033085256A84' */
-    cpy_r_r136 = CPyStatics[347]; /* '0xA35b1B31Ce002FBF2058D22F30f95D405200A15b' */
-    cpy_r_r137 = CPyStatics[348]; /* '0x64351fC9810aDAd17A690E4e1717Df5e7e085160' */
-    cpy_r_r138 = CPyStatics[349]; /* '0x821A278dFff762c76410264303F25bF42e195C0C' */
-    cpy_r_r139 = CPyStatics[350]; /* '0xa2E3356610840701BDf5611a53974510Ae27E2e1' */
-    cpy_r_r140 = CPyStatics[351]; /* '0x1BED97CBC3c24A4fb5C069C6E311a967386131f7' */
-    cpy_r_r141 = CPyStatics[352]; /* '0x3A65cbaebBFecbeA5D0CB523ab56fDbda7fF9aAA' */
-    cpy_r_r142 = CPyStatics[353]; /* '0x6951bDC4734b9f7F3E1B74afeBC670c736A0EDB6' */
-    cpy_r_r143 = CPyStatics[354]; /* '0xf1C9acDc66974dFB6dEcB12aA385b9cD01190E38' */
-    cpy_r_r144 = CPyStatics[355]; /* '0xCd5fE23C85820F7B72D0926FC9b05b43E359b7ee' */
-    cpy_r_r145 = CPyStatics[356]; /* '0x04C154b66CB340F3Ae24111CC767e0184Ed00Cc6' */
-    cpy_r_r146 = CPyStatics[357]; /* '0x005F893EcD7bF9667195642f7649DA8163e23658' */
-    cpy_r_r147 = CPyStatics[358]; /* '0xc2e660C62F72c2ad35AcE6DB78a616215E2F2222' */
-    cpy_r_r148 = CPyStatics[359]; /* '0xA1290d69c65A6Fe4DF752f95823fae25cB99e5A7' */
-    cpy_r_r149 = CPyStatics[360]; /* '0x09db87A538BD693E9d08544577d5cCfAA6373A48' */
-    cpy_r_r150 = CPyStatics[361]; /* '0x35Ec69A77B79c255e5d47D5A3BdbEFEfE342630c' */
-    cpy_r_r151 = CPyStatics[362]; /* '0xbf5495Efe5DB9ce00f80364C8B423567e58d2110' */
-    cpy_r_r152 = CPyStatics[363]; /* '0xFAe103DC9cf190eD75350761e95403b7b8aFa6c0' */
-    cpy_r_r153 = CPyStatics[364]; /* '0xEB4C2781e4ebA804CE9a9803C67d0893436bB27D' */
-    cpy_r_r154 = CPyStatics[365]; /* '0xfE18be6b3Bd88A2D2A7f928d00292E7a9963CfC6' */
-    cpy_r_r155 = CPyStatics[366]; /* '0x49849C98ae39Fff122806C06791Fa73784FB3675' */
-    cpy_r_r156 = CPyStatics[367]; /* '0x075b1bb99792c9E1041bA13afEf80C91a1e70fB3' */
-    cpy_r_r157 = CPyStatics[368]; /* '0xb19059ebb43466C323583928285a49f558E572Fd' */
-    cpy_r_r158 = CPyStatics[369]; /* '0x64eda51d3Ad40D56b9dFc5554E06F94e1Dd786Fd' */
-    cpy_r_r159 = CPyStatics[370]; /* '0xDE5331AC4B3630f94853Ff322B66407e0D6331E8' */
-    cpy_r_r160 = CPyStatics[371]; /* '0x410e3E86ef427e30B9235497143881f717d93c2A' */
-    cpy_r_r161 = CPyStatics[372]; /* '0x2fE94ea3d5d4a175184081439753DE15AeF9d614' */
-    cpy_r_r162 = CPyStatics[373]; /* '0x0327112423F3A68efdF1fcF402F6c5CB9f7C33fd' */
-    cpy_r_r163 = CPyStatics[374]; /* '0x3212b29E33587A00FB1C83346f5dBFA69A458923' */
-    cpy_r_r164 = CPyStatics[375]; /* '0x5228a22e72ccC52d415EcFd199F99D0665E7733b' */
-    cpy_r_r165 = CPyStatics[376]; /* '0xFbdCA68601f835b27790D98bbb8eC7f05FDEaA9B' */
-    cpy_r_r166 = CPyStatics[377]; /* '0x0316EB71485b0Ab14103307bf65a021042c6d380' */
-    cpy_r_r167 = CPyStatics[378]; /* '0x9BE89D2a4cd102D8Fecc6BF9dA793be995C22541' */
-    cpy_r_r168 = CPyStatics[379]; /* '0x8064d9Ae6cDf087b1bcd5BDf3531bD5d8C537a68' */
-    cpy_r_r169 = CPyStatics[380]; /* '0x8dAEBADE922dF735c38C80C7eBD708Af50815fAa' */
-    cpy_r_r170 = CPyStatics[381]; /* '0x8751D4196027d4e6DA63716fA7786B5174F04C15' */
-    cpy_r_r171 = CPyStatics[382]; /* '0x66eFF5221ca926636224650Fd3B9c497FF828F7D' */
-    cpy_r_r172 = CPyStatics[383]; /* '0x18084fbA666a33d37592fA2633fD49a74DD93a88' */
-    cpy_r_r173 = CPyStatics[384]; /* '0x661c70333AA1850CcDBAe82776Bb436A0fCfeEfB' */
-    cpy_r_r174 = CPyStatics[385]; /* '0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf' */
-    cpy_r_r175 = CPyStatics[386]; /* '0x45804880De22913dAFE09f4980848ECE6EcbAf78' */
-    cpy_r_r176 = CPyStatics[387]; /* '0x4922a015c4407F87432B179bb209e125432E4a2A' */
-    cpy_r_r177 = CPyStatics[388]; /* '0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e' */
-    cpy_r_r178 = CPyStatics[389]; /* '0xFf71841EeFca78a64421db28060855036765c248' */
-    cpy_r_r179 = CPyStatics[390]; /* '0xa3f152837492340dAAf201F4dFeC6cD73A8a9760' */
-    cpy_r_r180 = CPyStatics[391]; /* '0x41252E8691e964f7DE35156B68493bAb6797a275' */
-    cpy_r_r181 = CPyStatics[392]; /* '0x1cEB5cB57C4D4E2b2433641b95Dd330A33185A44' */
-    cpy_r_r182 = CPyStatics[393]; /* '0xD5525D397898e5502075Ea5E830d8914f6F0affe' */
-    cpy_r_r183 = CPyStatics[394]; /* '0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2' */
-    cpy_r_r184 = CPyStatics[395]; /* '0x3A283D9c08E8b55966afb64C515f5143cf907611' */
-    cpy_r_r185 = CPyStatics[396]; /* '0x23B608675a2B2fB1890d3ABBd85c5775c51691d5' */
-    cpy_r_r186 = CPyStatics[397]; /* '0xcA3d75aC011BF5aD07a98d02f18225F9bD9A6BDF' */
-    cpy_r_r187 = CPyStatics[398]; /* '0xc4AD29ba4B3c580e6D59105FFf484999997675Ff' */
-    cpy_r_r188 = CPyStatics[399]; /* '0xd075e95423C5c4BA1E122CaE0f4CdFA19b82881b' */
-    cpy_r_r189 = CPyStatics[400]; /* '0xe9F84dE264E91529aF07Fa2C746e934397810334' */
-    cpy_r_r190 = CPyStatics[401]; /* '0xa1d0E215a23d7030842FC67cE582a6aFa3CCaB83' */
-    cpy_r_r191 = CPyStatics[402]; /* '0x0fe629d1E84E171f8fF0C1Ded2Cc2221Caa48a3f' */
-    cpy_r_r192 = CPyStatics[403]; /* '0x5F0E628B693018f639D10e4A4F59BD4d8B2B6B44' */
-    cpy_r_r193 = CPyStatics[404]; /* '0xdBdb4d16EdA451D0503b854CF79D55697F90c8DF' */
-    cpy_r_r194 = CPyStatics[405]; /* '0x3aaDA3e213aBf8529606924d8D1c55CbDc70Bf74' */
-    cpy_r_r195 = CPyStatics[406]; /* '0x892A6f9dF0147e5f079b0993F486F9acA3c87881' */
-    cpy_r_r196 = CPyStatics[407]; /* '0x0ab87046fBb341D058F17CBC4c1133F25a20a52f' */
-    cpy_r_r197 = CPyStatics[408]; /* '0x97983236bE88107Cc8998733Ef73D8d969c52E37' */
-    cpy_r_r198 = CPyStatics[409]; /* '0x68749665FF8D2d112Fa859AA293F07A622782F38' */
-    cpy_r_r199 = CPyStatics[410]; /* '0xf5f5B97624542D72A9E06f04804Bf81baA15e2B4' */
-    cpy_r_r200 = CPyStatics[411]; /* '0x7F86Bf177Dd4F3494b841a37e810A34dD56c829B' */
-    cpy_r_r201 = CPyStatics[412]; /* '0x2889302a794dA87fBF1D6Db415C1492194663D13' */
-    cpy_r_r202 = CPyStatics[413]; /* '0xBfAb6FA95E0091ed66058ad493189D2cB29385E6' */
-    cpy_r_r203 = CPyStatics[414]; /* '0x8a4f252812dFF2A8636E4F7EB249d8FC2E3bd77f' */
-    cpy_r_r204 = CPyStatics[415]; /* '0x641927E970222B10b2E8CDBC96b1B4F427316f16' */
-    cpy_r_r205 = CPyStatics[416]; /* '0x9cea2eD9e47059260C97d697f82b8A14EfA61EA5' */
-    cpy_r_r206 = CPyStatics[417]; /* '0x269616D549D7e8Eaa82DFb17028d0B212D11232A' */
-    cpy_r_r207 = CPyStatics[418]; /* '0x69BbE2FA02b4D90A944fF328663667DC32786385' */
-    cpy_r_r208 = CPyStatics[419]; /* '0xD70240Dd62F4ea9a6A2416e0073D72139489d2AA' */
-    cpy_r_r209 = CPyStatics[420]; /* '0x114f1388fAB456c4bA31B1850b244Eedcd024136' */
-    cpy_r_r210 = CPyStatics[421]; /* '0xEA47B64e1BFCCb773A0420247C0aa0a3C1D2E5C5' */
+    cpy_r_r114 = CPyStatics[327]; /* '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE' */
+    cpy_r_r115 = CPyStatics[328]; /* '0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0' */
+    cpy_r_r116 = CPyStatics[329]; /* '0xA3D87FffcE63B53E0d54fAa1cc983B7eB0b74A9c' */
+    cpy_r_r117 = CPyStatics[330]; /* '0xaA17A236F2bAdc98DDc0Cf999AbB47D47Fc0A6Cf' */
+    cpy_r_r118 = CPyStatics[331]; /* '0x53a901d48795C58f485cBB38df08FA96a24669D5' */
+    cpy_r_r119 = CPyStatics[332]; /* '0xC4C319E2D4d66CcA4464C0c2B32c9Bd23ebe784e' */
+    cpy_r_r120 = CPyStatics[333]; /* '0x06325440D014e39736583c165C2963BA99fAf14E' */
+    cpy_r_r121 = CPyStatics[334]; /* '0x5e74C9036fb86BD7eCdcb084a0673EFc32eA31cb' */
+    cpy_r_r122 = CPyStatics[335]; /* '0xae78736Cd615f374D3085123A210448E74Fc6393' */
+    cpy_r_r123 = CPyStatics[336]; /* '0xE95A203B1a91a908F9B9CE46459d101078c2c3cb' */
+    cpy_r_r124 = CPyStatics[337]; /* '0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84' */
+    cpy_r_r125 = CPyStatics[338]; /* '0x9559Aaa82d9649C7A7b220E7c461d2E74c9a3593' */
+    cpy_r_r126 = CPyStatics[339]; /* '0x836A808d4828586A69364065A1e064609F5078c7' */
+    cpy_r_r127 = CPyStatics[340]; /* '0xc3D088842DcF02C13699F936BB83DFBBc6f721Ab' */
+    cpy_r_r128 = CPyStatics[341]; /* '0xC1330aCBbcE97cb9695B7ee161c0F95B875a8b0F' */
+    cpy_r_r129 = CPyStatics[342]; /* '0x5E8422345238F34275888049021821E8E08CAa1f' */
+    cpy_r_r130 = CPyStatics[343]; /* '0x856c4Efb76C1D1AE02e20CEB03A2A6a08b0b8dC3' */
+    cpy_r_r131 = CPyStatics[344]; /* '0xE72B141DF173b999AE7c1aDcbF60Cc9833Ce56a8' */
+    cpy_r_r132 = CPyStatics[345]; /* '0x3d1E5Cf16077F349e999d6b21A4f646e83Cd90c5' */
+    cpy_r_r133 = CPyStatics[346]; /* '0x0100546F2cD4C9D97f798fFC9755E47865FF7Ee6' */
+    cpy_r_r134 = CPyStatics[347]; /* '0xBe9895146f7AF43049ca1c1AE358B0541Ea49704' */
+    cpy_r_r135 = CPyStatics[348]; /* '0x7C07F7aBe10CE8e33DC6C5aD68FE033085256A84' */
+    cpy_r_r136 = CPyStatics[349]; /* '0xA35b1B31Ce002FBF2058D22F30f95D405200A15b' */
+    cpy_r_r137 = CPyStatics[350]; /* '0x64351fC9810aDAd17A690E4e1717Df5e7e085160' */
+    cpy_r_r138 = CPyStatics[351]; /* '0x821A278dFff762c76410264303F25bF42e195C0C' */
+    cpy_r_r139 = CPyStatics[352]; /* '0xa2E3356610840701BDf5611a53974510Ae27E2e1' */
+    cpy_r_r140 = CPyStatics[353]; /* '0x1BED97CBC3c24A4fb5C069C6E311a967386131f7' */
+    cpy_r_r141 = CPyStatics[354]; /* '0x3A65cbaebBFecbeA5D0CB523ab56fDbda7fF9aAA' */
+    cpy_r_r142 = CPyStatics[355]; /* '0x6951bDC4734b9f7F3E1B74afeBC670c736A0EDB6' */
+    cpy_r_r143 = CPyStatics[356]; /* '0xf1C9acDc66974dFB6dEcB12aA385b9cD01190E38' */
+    cpy_r_r144 = CPyStatics[357]; /* '0xCd5fE23C85820F7B72D0926FC9b05b43E359b7ee' */
+    cpy_r_r145 = CPyStatics[358]; /* '0x04C154b66CB340F3Ae24111CC767e0184Ed00Cc6' */
+    cpy_r_r146 = CPyStatics[359]; /* '0x005F893EcD7bF9667195642f7649DA8163e23658' */
+    cpy_r_r147 = CPyStatics[360]; /* '0xc2e660C62F72c2ad35AcE6DB78a616215E2F2222' */
+    cpy_r_r148 = CPyStatics[361]; /* '0xA1290d69c65A6Fe4DF752f95823fae25cB99e5A7' */
+    cpy_r_r149 = CPyStatics[362]; /* '0x09db87A538BD693E9d08544577d5cCfAA6373A48' */
+    cpy_r_r150 = CPyStatics[363]; /* '0x35Ec69A77B79c255e5d47D5A3BdbEFEfE342630c' */
+    cpy_r_r151 = CPyStatics[364]; /* '0xbf5495Efe5DB9ce00f80364C8B423567e58d2110' */
+    cpy_r_r152 = CPyStatics[365]; /* '0xFAe103DC9cf190eD75350761e95403b7b8aFa6c0' */
+    cpy_r_r153 = CPyStatics[366]; /* '0xEB4C2781e4ebA804CE9a9803C67d0893436bB27D' */
+    cpy_r_r154 = CPyStatics[367]; /* '0xfE18be6b3Bd88A2D2A7f928d00292E7a9963CfC6' */
+    cpy_r_r155 = CPyStatics[368]; /* '0x49849C98ae39Fff122806C06791Fa73784FB3675' */
+    cpy_r_r156 = CPyStatics[369]; /* '0x075b1bb99792c9E1041bA13afEf80C91a1e70fB3' */
+    cpy_r_r157 = CPyStatics[370]; /* '0xb19059ebb43466C323583928285a49f558E572Fd' */
+    cpy_r_r158 = CPyStatics[371]; /* '0x64eda51d3Ad40D56b9dFc5554E06F94e1Dd786Fd' */
+    cpy_r_r159 = CPyStatics[372]; /* '0xDE5331AC4B3630f94853Ff322B66407e0D6331E8' */
+    cpy_r_r160 = CPyStatics[373]; /* '0x410e3E86ef427e30B9235497143881f717d93c2A' */
+    cpy_r_r161 = CPyStatics[374]; /* '0x2fE94ea3d5d4a175184081439753DE15AeF9d614' */
+    cpy_r_r162 = CPyStatics[375]; /* '0x0327112423F3A68efdF1fcF402F6c5CB9f7C33fd' */
+    cpy_r_r163 = CPyStatics[376]; /* '0x3212b29E33587A00FB1C83346f5dBFA69A458923' */
+    cpy_r_r164 = CPyStatics[377]; /* '0x5228a22e72ccC52d415EcFd199F99D0665E7733b' */
+    cpy_r_r165 = CPyStatics[378]; /* '0xFbdCA68601f835b27790D98bbb8eC7f05FDEaA9B' */
+    cpy_r_r166 = CPyStatics[379]; /* '0x0316EB71485b0Ab14103307bf65a021042c6d380' */
+    cpy_r_r167 = CPyStatics[380]; /* '0x9BE89D2a4cd102D8Fecc6BF9dA793be995C22541' */
+    cpy_r_r168 = CPyStatics[381]; /* '0x8064d9Ae6cDf087b1bcd5BDf3531bD5d8C537a68' */
+    cpy_r_r169 = CPyStatics[382]; /* '0x8dAEBADE922dF735c38C80C7eBD708Af50815fAa' */
+    cpy_r_r170 = CPyStatics[383]; /* '0x8751D4196027d4e6DA63716fA7786B5174F04C15' */
+    cpy_r_r171 = CPyStatics[384]; /* '0x66eFF5221ca926636224650Fd3B9c497FF828F7D' */
+    cpy_r_r172 = CPyStatics[385]; /* '0x18084fbA666a33d37592fA2633fD49a74DD93a88' */
+    cpy_r_r173 = CPyStatics[386]; /* '0x661c70333AA1850CcDBAe82776Bb436A0fCfeEfB' */
+    cpy_r_r174 = CPyStatics[387]; /* '0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf' */
+    cpy_r_r175 = CPyStatics[388]; /* '0x45804880De22913dAFE09f4980848ECE6EcbAf78' */
+    cpy_r_r176 = CPyStatics[389]; /* '0x4922a015c4407F87432B179bb209e125432E4a2A' */
+    cpy_r_r177 = CPyStatics[390]; /* '0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e' */
+    cpy_r_r178 = CPyStatics[391]; /* '0xFf71841EeFca78a64421db28060855036765c248' */
+    cpy_r_r179 = CPyStatics[392]; /* '0xa3f152837492340dAAf201F4dFeC6cD73A8a9760' */
+    cpy_r_r180 = CPyStatics[393]; /* '0x41252E8691e964f7DE35156B68493bAb6797a275' */
+    cpy_r_r181 = CPyStatics[394]; /* '0x1cEB5cB57C4D4E2b2433641b95Dd330A33185A44' */
+    cpy_r_r182 = CPyStatics[395]; /* '0xD5525D397898e5502075Ea5E830d8914f6F0affe' */
+    cpy_r_r183 = CPyStatics[396]; /* '0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2' */
+    cpy_r_r184 = CPyStatics[397]; /* '0x3A283D9c08E8b55966afb64C515f5143cf907611' */
+    cpy_r_r185 = CPyStatics[398]; /* '0x23B608675a2B2fB1890d3ABBd85c5775c51691d5' */
+    cpy_r_r186 = CPyStatics[399]; /* '0xcA3d75aC011BF5aD07a98d02f18225F9bD9A6BDF' */
+    cpy_r_r187 = CPyStatics[400]; /* '0xc4AD29ba4B3c580e6D59105FFf484999997675Ff' */
+    cpy_r_r188 = CPyStatics[401]; /* '0xd075e95423C5c4BA1E122CaE0f4CdFA19b82881b' */
+    cpy_r_r189 = CPyStatics[402]; /* '0xe9F84dE264E91529aF07Fa2C746e934397810334' */
+    cpy_r_r190 = CPyStatics[403]; /* '0xa1d0E215a23d7030842FC67cE582a6aFa3CCaB83' */
+    cpy_r_r191 = CPyStatics[404]; /* '0x0fe629d1E84E171f8fF0C1Ded2Cc2221Caa48a3f' */
+    cpy_r_r192 = CPyStatics[405]; /* '0x5F0E628B693018f639D10e4A4F59BD4d8B2B6B44' */
+    cpy_r_r193 = CPyStatics[406]; /* '0xdBdb4d16EdA451D0503b854CF79D55697F90c8DF' */
+    cpy_r_r194 = CPyStatics[407]; /* '0x3aaDA3e213aBf8529606924d8D1c55CbDc70Bf74' */
+    cpy_r_r195 = CPyStatics[408]; /* '0x892A6f9dF0147e5f079b0993F486F9acA3c87881' */
+    cpy_r_r196 = CPyStatics[409]; /* '0x0ab87046fBb341D058F17CBC4c1133F25a20a52f' */
+    cpy_r_r197 = CPyStatics[410]; /* '0x97983236bE88107Cc8998733Ef73D8d969c52E37' */
+    cpy_r_r198 = CPyStatics[411]; /* '0x68749665FF8D2d112Fa859AA293F07A622782F38' */
+    cpy_r_r199 = CPyStatics[412]; /* '0xf5f5B97624542D72A9E06f04804Bf81baA15e2B4' */
+    cpy_r_r200 = CPyStatics[413]; /* '0x7F86Bf177Dd4F3494b841a37e810A34dD56c829B' */
+    cpy_r_r201 = CPyStatics[414]; /* '0x2889302a794dA87fBF1D6Db415C1492194663D13' */
+    cpy_r_r202 = CPyStatics[415]; /* '0xBfAb6FA95E0091ed66058ad493189D2cB29385E6' */
+    cpy_r_r203 = CPyStatics[416]; /* '0x8a4f252812dFF2A8636E4F7EB249d8FC2E3bd77f' */
+    cpy_r_r204 = CPyStatics[417]; /* '0x641927E970222B10b2E8CDBC96b1B4F427316f16' */
+    cpy_r_r205 = CPyStatics[418]; /* '0x9cea2eD9e47059260C97d697f82b8A14EfA61EA5' */
+    cpy_r_r206 = CPyStatics[419]; /* '0x269616D549D7e8Eaa82DFb17028d0B212D11232A' */
+    cpy_r_r207 = CPyStatics[420]; /* '0x69BbE2FA02b4D90A944fF328663667DC32786385' */
+    cpy_r_r208 = CPyStatics[421]; /* '0xD70240Dd62F4ea9a6A2416e0073D72139489d2AA' */
+    cpy_r_r209 = CPyStatics[422]; /* '0x114f1388fAB456c4bA31B1850b244Eedcd024136' */
+    cpy_r_r210 = CPyStatics[423]; /* '0xEA47B64e1BFCCb773A0420247C0aa0a3C1D2E5C5' */
     cpy_r_r211 = PySet_New(NULL);
     if (unlikely(cpy_r_r211 == NULL)) {
         CPy_AddTraceback("y/prices/utils/sense_check.py", "<module>", 40, CPyStatic_sense_check___globals);
@@ -25381,10 +25490,10 @@ CPyL135: ;
     }
     CPy_Unreachable();
 CPyL137: ;
-    cpy_r_r408 = CPyStatics[422]; /* '0x8d0e18c97e5dd8ee2b539ae8cd3a3654df5d79e5' */
-    cpy_r_r409 = CPyStatics[423]; /* '0xbfF4a34A4644a113E8200D7F1D79b3555f723AfE' */
-    cpy_r_r410 = CPyStatics[424]; /* '0x7130d2A12B9BCbFAe4f2634d864A1Ee1Ce3Ead9c' */
-    cpy_r_r411 = CPyStatics[425]; /* '0x08FC9Ba2cAc74742177e0afC3dC8Aed6961c24e7' */
+    cpy_r_r408 = CPyStatics[424]; /* '0x8d0e18c97e5dd8ee2b539ae8cd3a3654df5d79e5' */
+    cpy_r_r409 = CPyStatics[425]; /* '0xbfF4a34A4644a113E8200D7F1D79b3555f723AfE' */
+    cpy_r_r410 = CPyStatics[426]; /* '0x7130d2A12B9BCbFAe4f2634d864A1Ee1Ce3Ead9c' */
+    cpy_r_r411 = CPyStatics[427]; /* '0x08FC9Ba2cAc74742177e0afC3dC8Aed6961c24e7' */
     cpy_r_r412 = PySet_New(NULL);
     if (unlikely(cpy_r_r412 == NULL)) {
         CPy_AddTraceback("y/prices/utils/sense_check.py", "<module>", 144, CPyStatic_sense_check___globals);
@@ -25428,12 +25537,12 @@ CPyL143: ;
     }
     CPy_Unreachable();
 CPyL145: ;
-    cpy_r_r423 = CPyStatics[426]; /* '0xBDC8fd437C489Ca3c6DA3B5a336D11532a532303' */
-    cpy_r_r424 = CPyStatics[427]; /* '0xDBf31dF14B66535aF65AaC99C32e9eA844e14501' */
-    cpy_r_r425 = CPyStatics[428]; /* '0x2406dCe4dA5aB125A18295f4fB9FD36a0f7879A2' */
-    cpy_r_r426 = CPyStatics[429]; /* '0x29b0Da86e484E1C0029B56e817912d778aC0EC69' */
-    cpy_r_r427 = CPyStatics[430]; /* '0xf43Cc235E686d7BC513F53Fbffb61F760c3a1882' */
-    cpy_r_r428 = CPyStatics[431]; /* '0x58e57cA18B7A47112b877E31929798Cd3D703b0f' */
+    cpy_r_r423 = CPyStatics[428]; /* '0xBDC8fd437C489Ca3c6DA3B5a336D11532a532303' */
+    cpy_r_r424 = CPyStatics[429]; /* '0xDBf31dF14B66535aF65AaC99C32e9eA844e14501' */
+    cpy_r_r425 = CPyStatics[430]; /* '0x2406dCe4dA5aB125A18295f4fB9FD36a0f7879A2' */
+    cpy_r_r426 = CPyStatics[431]; /* '0x29b0Da86e484E1C0029B56e817912d778aC0EC69' */
+    cpy_r_r427 = CPyStatics[432]; /* '0xf43Cc235E686d7BC513F53Fbffb61F760c3a1882' */
+    cpy_r_r428 = CPyStatics[433]; /* '0x58e57cA18B7A47112b877E31929798Cd3D703b0f' */
     cpy_r_r429 = PySet_New(NULL);
     if (unlikely(cpy_r_r429 == NULL)) {
         CPy_AddTraceback("y/prices/utils/sense_check.py", "<module>", 152, CPyStatic_sense_check___globals);
@@ -25489,8 +25598,8 @@ CPyL153: ;
     }
     CPy_Unreachable();
 CPyL155: ;
-    cpy_r_r444 = CPyStatics[427]; /* '0xDBf31dF14B66535aF65AaC99C32e9eA844e14501' */
-    cpy_r_r445 = CPyStatics[432]; /* '0xd6070ae98b8069de6B494332d1A1a81B6179D960' */
+    cpy_r_r444 = CPyStatics[429]; /* '0xDBf31dF14B66535aF65AaC99C32e9eA844e14501' */
+    cpy_r_r445 = CPyStatics[434]; /* '0xd6070ae98b8069de6B494332d1A1a81B6179D960' */
     cpy_r_r446 = PySet_New(NULL);
     if (unlikely(cpy_r_r446 == NULL)) {
         CPy_AddTraceback("y/prices/utils/sense_check.py", "<module>", 163, CPyStatic_sense_check___globals);
@@ -25522,19 +25631,19 @@ CPyL159: ;
     }
     CPy_Unreachable();
 CPyL161: ;
-    cpy_r_r453 = CPyStatics[325]; /* '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE' */
-    cpy_r_r454 = CPyStatics[433]; /* '0x9Bcef72be871e61ED4fBbc7630889beE758eb81D' */
-    cpy_r_r455 = CPyStatics[434]; /* '0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb' */
-    cpy_r_r456 = CPyStatics[435]; /* '0x6806411765Af15Bddd26f8f544A34cC40cb9838B' */
-    cpy_r_r457 = CPyStatics[436]; /* '0x484c2D6e3cDd945a8B2DF735e079178C1036578c' */
-    cpy_r_r458 = CPyStatics[437]; /* '0x1610e3c85dd44Af31eD7f33a63642012Dca0C5A5' */
-    cpy_r_r459 = CPyStatics[438]; /* '0x3E29D3A9316dAB217754d13b28646B76607c5f04' */
-    cpy_r_r460 = CPyStatics[439]; /* '0xE405de8F52ba7559f9df3C368500B6E6ae6Cee49' */
-    cpy_r_r461 = CPyStatics[440]; /* '0x300d2c875C6fb8Ce4bf5480B4d34b7c9ea8a33A4' */
-    cpy_r_r462 = CPyStatics[441]; /* '0x298B9B95708152ff6968aafd889c6586e9169f1D' */
-    cpy_r_r463 = CPyStatics[442]; /* '0x6c84a8f1c29108F47a79964b5Fe888D4f4D0dE40' */
-    cpy_r_r464 = CPyStatics[443]; /* '0xd62C9D8a3D4fd98b27CaaEfE3571782a3aF0a737' */
-    cpy_r_r465 = CPyStatics[444]; /* '0x6C5019D345Ec05004A7E7B0623A91a0D9B8D590d' */
+    cpy_r_r453 = CPyStatics[327]; /* '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE' */
+    cpy_r_r454 = CPyStatics[435]; /* '0x9Bcef72be871e61ED4fBbc7630889beE758eb81D' */
+    cpy_r_r455 = CPyStatics[436]; /* '0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb' */
+    cpy_r_r456 = CPyStatics[437]; /* '0x6806411765Af15Bddd26f8f544A34cC40cb9838B' */
+    cpy_r_r457 = CPyStatics[438]; /* '0x484c2D6e3cDd945a8B2DF735e079178C1036578c' */
+    cpy_r_r458 = CPyStatics[439]; /* '0x1610e3c85dd44Af31eD7f33a63642012Dca0C5A5' */
+    cpy_r_r459 = CPyStatics[440]; /* '0x3E29D3A9316dAB217754d13b28646B76607c5f04' */
+    cpy_r_r460 = CPyStatics[441]; /* '0xE405de8F52ba7559f9df3C368500B6E6ae6Cee49' */
+    cpy_r_r461 = CPyStatics[442]; /* '0x300d2c875C6fb8Ce4bf5480B4d34b7c9ea8a33A4' */
+    cpy_r_r462 = CPyStatics[443]; /* '0x298B9B95708152ff6968aafd889c6586e9169f1D' */
+    cpy_r_r463 = CPyStatics[444]; /* '0x6c84a8f1c29108F47a79964b5Fe888D4f4D0dE40' */
+    cpy_r_r464 = CPyStatics[445]; /* '0xd62C9D8a3D4fd98b27CaaEfE3571782a3aF0a737' */
+    cpy_r_r465 = CPyStatics[446]; /* '0x6C5019D345Ec05004A7E7B0623A91a0D9B8D590d' */
     cpy_r_r466 = PySet_New(NULL);
     if (unlikely(cpy_r_r466 == NULL)) {
         CPy_AddTraceback("y/prices/utils/sense_check.py", "<module>", 169, CPyStatic_sense_check___globals);
@@ -25632,7 +25741,7 @@ CPyL176: ;
     }
     CPy_Unreachable();
 CPyL178: ;
-    cpy_r_r495 = CPyStatics[445]; /* '0x8e0B8c8BB9db49a46697F3a5Bb8A308e744821D2' */
+    cpy_r_r495 = CPyStatics[447]; /* '0x8e0B8c8BB9db49a46697F3a5Bb8A308e744821D2' */
     cpy_r_r496 = PySet_New(NULL);
     if (unlikely(cpy_r_r496 == NULL)) {
         CPy_AddTraceback("y/prices/utils/sense_check.py", "<module>", 187, CPyStatic_sense_check___globals);
@@ -25658,12 +25767,12 @@ CPyL181: ;
     }
     CPy_Unreachable();
 CPyL183: ;
-    cpy_r_r501 = CPyStatics[446]; /* '0x2Ae3F1Ec7F1F5012CFEab0185bfc7aa3cf0DEc22' */
-    cpy_r_r502 = CPyStatics[447]; /* '0xc1CBa3fCea344f92D9239c08C0568f6F2F0ee452' */
-    cpy_r_r503 = CPyStatics[448]; /* '0x1f55a02A049033E3419a8E2975cF3F572F4e6E9A' */
-    cpy_r_r504 = CPyStatics[449]; /* '0xCb327b99fF831bF8223cCEd12B1338FF3aA322Ff' */
-    cpy_r_r505 = CPyStatics[450]; /* '0x236aa50979D5f3De3Bd1Eeb40E81137F22ab794b' */
-    cpy_r_r506 = CPyStatics[451]; /* '0xcb327b99ff831bf8223cced12b1338ff3aa322ff' */
+    cpy_r_r501 = CPyStatics[448]; /* '0x2Ae3F1Ec7F1F5012CFEab0185bfc7aa3cf0DEc22' */
+    cpy_r_r502 = CPyStatics[449]; /* '0xc1CBa3fCea344f92D9239c08C0568f6F2F0ee452' */
+    cpy_r_r503 = CPyStatics[450]; /* '0x1f55a02A049033E3419a8E2975cF3F572F4e6E9A' */
+    cpy_r_r504 = CPyStatics[451]; /* '0xCb327b99fF831bF8223cCEd12B1338FF3aA322Ff' */
+    cpy_r_r505 = CPyStatics[452]; /* '0x236aa50979D5f3De3Bd1Eeb40E81137F22ab794b' */
+    cpy_r_r506 = CPyStatics[453]; /* '0xcb327b99ff831bf8223cced12b1338ff3aa322ff' */
     cpy_r_r507 = PySet_New(NULL);
     if (unlikely(cpy_r_r507 == NULL)) {
         CPy_AddTraceback("y/prices/utils/sense_check.py", "<module>", 190, CPyStatic_sense_check___globals);
@@ -25718,7 +25827,7 @@ CPyL183: ;
         goto CPyL202;
     }
     cpy_r_r521 = CPyStatic_sense_check___globals;
-    cpy_r_r522 = CPyStatics[271]; /* 'CHAINID' */
+    cpy_r_r522 = CPyStatics[273]; /* 'CHAINID' */
     cpy_r_r523 = CPyDict_GetItem(cpy_r_r521, cpy_r_r522);
     if (unlikely(cpy_r_r523 == NULL)) {
         CPy_AddTraceback("y/prices/utils/sense_check.py", "<module>", 200, CPyStatic_sense_check___globals);
@@ -25779,7 +25888,7 @@ CPyL198: ;
     CPy_INCREF(CPyStatic_sense_check___ACCEPTABLE_HIGH_PRICES);
     CPy_DECREF(cpy_r_r531);
     cpy_r_r532 = CPyStatic_sense_check___globals;
-    cpy_r_r533 = CPyStatics[452]; /* 'ACCEPTABLE_HIGH_PRICES' */
+    cpy_r_r533 = CPyStatics[454]; /* 'ACCEPTABLE_HIGH_PRICES' */
     cpy_r_r534 = CPyDict_SetItem(cpy_r_r532, cpy_r_r533, cpy_r_r530);
     CPy_DECREF(cpy_r_r530);
     cpy_r_r535 = cpy_r_r534 >= 0;
@@ -26870,7 +26979,7 @@ CPyL6: ;
         CPy_AddTraceback("y/utils/gather.py", "gather_methods", 51, CPyStatic_gather___globals);
         goto CPyL101;
     }
-    cpy_r_r11 = CPyStatics[77]; /* '(' */
+    cpy_r_r11 = CPyStatics[82]; /* '(' */
     cpy_r_r12 = ((y___utils___gather___gather_methods_envObject *)cpy_r_r4)->_methods;
     if (unlikely(cpy_r_r12 == NULL)) {
         CPy_AttributeError("y/utils/gather.py", "gather_methods", "gather_methods_env", "methods", 52, CPyStatic_gather___globals);
@@ -26943,7 +27052,7 @@ CPyL18: ;
     }
 CPyL19: ;
     cpy_r_r24 = CPyStatic_gather___globals;
-    cpy_r_r25 = CPyStatics[453]; /* '_gather_methods_raw' */
+    cpy_r_r25 = CPyStatics[455]; /* '_gather_methods_raw' */
     cpy_r_r26 = CPyDict_GetItem(cpy_r_r24, cpy_r_r25);
     if (unlikely(cpy_r_r26 == NULL)) {
         CPy_AddTraceback("y/utils/gather.py", "gather_methods", 53, CPyStatic_gather___globals);
@@ -26952,7 +27061,7 @@ CPyL19: ;
     cpy_r_r27 = cpy_r_r23 ? Py_True : Py_False;
     PyObject *cpy_r_r28[4] = {cpy_r_r19, cpy_r_r21, cpy_r_r22, cpy_r_r27};
     cpy_r_r29 = (PyObject **)&cpy_r_r28;
-    cpy_r_r30 = CPyStatics[545]; /* ('block', 'return_exceptions') */
+    cpy_r_r30 = CPyStatics[546]; /* ('block', 'return_exceptions') */
     cpy_r_r31 = PyObject_Vectorcall(cpy_r_r26, cpy_r_r29, 2, cpy_r_r30);
     CPy_DECREF(cpy_r_r26);
     if (unlikely(cpy_r_r31 == NULL)) {
@@ -27187,7 +27296,7 @@ CPyL58: ;
     }
 CPyL59: ;
     cpy_r_r61 = CPyStatic_gather___globals;
-    cpy_r_r62 = CPyStatics[455]; /* '_gather_methods_brownie' */
+    cpy_r_r62 = CPyStatics[457]; /* '_gather_methods_brownie' */
     cpy_r_r63 = CPyDict_GetItem(cpy_r_r61, cpy_r_r62);
     if (unlikely(cpy_r_r63 == NULL)) {
         CPy_AddTraceback("y/utils/gather.py", "gather_methods", 57, CPyStatic_gather___globals);
@@ -27196,7 +27305,7 @@ CPyL59: ;
     cpy_r_r64 = cpy_r_r60 ? Py_True : Py_False;
     PyObject *cpy_r_r65[4] = {cpy_r_r56, cpy_r_r58, cpy_r_r59, cpy_r_r64};
     cpy_r_r66 = (PyObject **)&cpy_r_r65;
-    cpy_r_r67 = CPyStatics[545]; /* ('block', 'return_exceptions') */
+    cpy_r_r67 = CPyStatics[546]; /* ('block', 'return_exceptions') */
     cpy_r_r68 = PyObject_Vectorcall(cpy_r_r63, cpy_r_r66, 2, cpy_r_r67);
     CPy_DECREF(cpy_r_r63);
     if (unlikely(cpy_r_r68 == NULL)) {
@@ -27778,7 +27887,7 @@ PyObject *CPyDef_gather___gather_methods_gen___close(PyObject *cpy_r___mypyc_sel
     char cpy_r_r14;
     PyObject *cpy_r_r15;
     cpy_r_r0 = CPyModule_builtins;
-    cpy_r_r1 = CPyStatics[145]; /* 'GeneratorExit' */
+    cpy_r_r1 = CPyStatics[147]; /* 'GeneratorExit' */
     cpy_r_r2 = CPyObject_GetAttr(cpy_r_r0, cpy_r_r1);
     if (cpy_r_r2 == NULL) goto CPyL3;
     cpy_r_r3 = (PyObject *)&_Py_NoneStruct;
@@ -27788,7 +27897,7 @@ PyObject *CPyDef_gather___gather_methods_gen___close(PyObject *cpy_r___mypyc_sel
 CPyL3: ;
     cpy_r_r6 = CPy_CatchError();
     cpy_r_r7 = CPyModule_builtins;
-    cpy_r_r8 = CPyStatics[146]; /* 'StopIteration' */
+    cpy_r_r8 = CPyStatics[148]; /* 'StopIteration' */
     cpy_r_r9 = CPyObject_GetAttr(cpy_r_r7, cpy_r_r8);
     if (cpy_r_r9 == NULL) goto CPyL12;
     cpy_r_r10.f0 = cpy_r_r2;
@@ -28190,8 +28299,8 @@ CPyL3: ;
     }
     CPy_Unreachable();
 CPyL5: ;
-    cpy_r_r8 = CPyStatics[526]; /* ('Contract',) */
-    cpy_r_r9 = CPyStatics[99]; /* 'y' */
+    cpy_r_r8 = CPyStatics[527]; /* ('Contract',) */
+    cpy_r_r9 = CPyStatics[48]; /* 'y' */
     cpy_r_r10 = CPyStatic_gather___globals;
     cpy_r_r11 = CPyImport_ImportFromMany(cpy_r_r9, cpy_r_r8, cpy_r_r8, cpy_r_r10);
     if (unlikely(cpy_r_r11 == NULL)) {
@@ -28202,7 +28311,7 @@ CPyL5: ;
     CPy_INCREF(CPyModule_y);
     CPy_DECREF(cpy_r_r11);
     cpy_r_r12 = CPyStatic_gather___globals;
-    cpy_r_r13 = CPyStatics[210]; /* 'Contract' */
+    cpy_r_r13 = CPyStatics[212]; /* 'Contract' */
     cpy_r_r14 = CPyDict_GetItem(cpy_r_r12, cpy_r_r13);
     if (unlikely(cpy_r_r14 == NULL)) {
         CPy_AddTraceback("y/utils/gather.py", "_gather_methods_brownie", 94, CPyStatic_gather___globals);
@@ -28215,7 +28324,7 @@ CPyL5: ;
     }
     CPy_INCREF(cpy_r_r15);
 CPyL8: ;
-    cpy_r_r16 = CPyStatics[308]; /* 'coroutine' */
+    cpy_r_r16 = CPyStatics[310]; /* 'coroutine' */
     PyObject *cpy_r_r17[2] = {cpy_r_r14, cpy_r_r15};
     cpy_r_r18 = (PyObject **)&cpy_r_r17;
     cpy_r_r19 = PyObject_VectorcallMethod(cpy_r_r16, cpy_r_r18, 9223372036854775810ULL, 0);
@@ -28521,10 +28630,10 @@ CPyL54: ;
     }
     CPy_INCREF(cpy_r_r64);
 CPyL56: ;
-    cpy_r_r65 = CPyStatics[308]; /* 'coroutine' */
+    cpy_r_r65 = CPyStatics[310]; /* 'coroutine' */
     PyObject *cpy_r_r66[2] = {cpy_r_r63, cpy_r_r64};
     cpy_r_r67 = (PyObject **)&cpy_r_r66;
-    cpy_r_r68 = CPyStatics[546]; /* ('block_identifier',) */
+    cpy_r_r68 = CPyStatics[547]; /* ('block_identifier',) */
     cpy_r_r69 = PyObject_VectorcallMethod(cpy_r_r65, cpy_r_r67, 9223372036854775809ULL, cpy_r_r68);
     if (unlikely(cpy_r_r69 == NULL)) {
         CPy_AddTraceback("y/utils/gather.py", "_gather_methods_brownie", 96, CPyStatic_gather___globals);
@@ -28581,7 +28690,7 @@ CPyL65: ;
     cpy_r_r78 = cpy_r_r75 ? Py_True : Py_False;
     PyObject *cpy_r_r79[2] = {cpy_r_r74, cpy_r_r78};
     cpy_r_r80 = (PyObject **)&cpy_r_r79;
-    cpy_r_r81 = CPyStatics[547]; /* ('return_exceptions',) */
+    cpy_r_r81 = CPyStatics[548]; /* ('return_exceptions',) */
     cpy_r_r82 = PyObject_Vectorcall(cpy_r_r76, cpy_r_r80, 1, cpy_r_r81);
     if (unlikely(cpy_r_r82 == NULL)) {
         CPy_AddTraceback("y/utils/gather.py", "_gather_methods_brownie", 95, CPyStatic_gather___globals);
@@ -29174,7 +29283,7 @@ PyObject *CPyDef_gather____gather_methods_brownie_gen___close(PyObject *cpy_r___
     char cpy_r_r14;
     PyObject *cpy_r_r15;
     cpy_r_r0 = CPyModule_builtins;
-    cpy_r_r1 = CPyStatics[145]; /* 'GeneratorExit' */
+    cpy_r_r1 = CPyStatics[147]; /* 'GeneratorExit' */
     cpy_r_r2 = CPyObject_GetAttr(cpy_r_r0, cpy_r_r1);
     if (cpy_r_r2 == NULL) goto CPyL3;
     cpy_r_r3 = (PyObject *)&_Py_NoneStruct;
@@ -29184,7 +29293,7 @@ PyObject *CPyDef_gather____gather_methods_brownie_gen___close(PyObject *cpy_r___
 CPyL3: ;
     cpy_r_r6 = CPy_CatchError();
     cpy_r_r7 = CPyModule_builtins;
-    cpy_r_r8 = CPyStatics[146]; /* 'StopIteration' */
+    cpy_r_r8 = CPyStatics[148]; /* 'StopIteration' */
     cpy_r_r9 = CPyObject_GetAttr(cpy_r_r7, cpy_r_r8);
     if (cpy_r_r9 == NULL) goto CPyL12;
     cpy_r_r10.f0 = cpy_r_r2;
@@ -29690,7 +29799,7 @@ CPyL23: ;
 CPyL25: ;
     PyObject *cpy_r_r32[3] = {cpy_r_r24, cpy_r_r26, cpy_r_r29};
     cpy_r_r33 = (PyObject **)&cpy_r_r32;
-    cpy_r_r34 = CPyStatics[548]; /* ('block_id',) */
+    cpy_r_r34 = CPyStatics[549]; /* ('block_id',) */
     cpy_r_r35 = PyObject_Vectorcall(cpy_r_r30, cpy_r_r33, 2, cpy_r_r34);
     if (unlikely(cpy_r_r35 == NULL)) {
         CPy_AddTraceback("y/utils/gather.py", "_gather_methods_raw", 131, CPyStatic_gather___globals);
@@ -29748,7 +29857,7 @@ CPyL34: ;
     cpy_r_r44 = cpy_r_r41 ? Py_True : Py_False;
     PyObject *cpy_r_r45[2] = {cpy_r_r40, cpy_r_r44};
     cpy_r_r46 = (PyObject **)&cpy_r_r45;
-    cpy_r_r47 = CPyStatics[547]; /* ('return_exceptions',) */
+    cpy_r_r47 = CPyStatics[548]; /* ('return_exceptions',) */
     cpy_r_r48 = PyObject_Vectorcall(cpy_r_r42, cpy_r_r46, 1, cpy_r_r47);
     if (unlikely(cpy_r_r48 == NULL)) {
         CPy_AddTraceback("y/utils/gather.py", "_gather_methods_raw", 130, CPyStatic_gather___globals);
@@ -30288,7 +30397,7 @@ PyObject *CPyDef_gather____gather_methods_raw_gen___close(PyObject *cpy_r___mypy
     char cpy_r_r14;
     PyObject *cpy_r_r15;
     cpy_r_r0 = CPyModule_builtins;
-    cpy_r_r1 = CPyStatics[145]; /* 'GeneratorExit' */
+    cpy_r_r1 = CPyStatics[147]; /* 'GeneratorExit' */
     cpy_r_r2 = CPyObject_GetAttr(cpy_r_r0, cpy_r_r1);
     if (cpy_r_r2 == NULL) goto CPyL3;
     cpy_r_r3 = (PyObject *)&_Py_NoneStruct;
@@ -30298,7 +30407,7 @@ PyObject *CPyDef_gather____gather_methods_raw_gen___close(PyObject *cpy_r___mypy
 CPyL3: ;
     cpy_r_r6 = CPy_CatchError();
     cpy_r_r7 = CPyModule_builtins;
-    cpy_r_r8 = CPyStatics[146]; /* 'StopIteration' */
+    cpy_r_r8 = CPyStatics[148]; /* 'StopIteration' */
     cpy_r_r9 = CPyObject_GetAttr(cpy_r_r7, cpy_r_r8);
     if (cpy_r_r9 == NULL) goto CPyL12;
     cpy_r_r10.f0 = cpy_r_r2;
@@ -30639,7 +30748,7 @@ char CPyDef_gather_____top_level__(void) {
     CPy_INCREF(CPyModule_builtins);
     CPy_DECREF(cpy_r_r4);
 CPyL3: ;
-    cpy_r_r5 = CPyStatics[549]; /* ('Any', 'Final', 'Iterable', 'List', 'Optional', 'Tuple') */
+    cpy_r_r5 = CPyStatics[550]; /* ('Any', 'Final', 'Iterable', 'List', 'Optional', 'Tuple') */
     cpy_r_r6 = CPyStatics[37]; /* 'typing' */
     cpy_r_r7 = CPyStatic_gather___globals;
     cpy_r_r8 = CPyImport_ImportFromMany(cpy_r_r6, cpy_r_r5, cpy_r_r5, cpy_r_r7);
@@ -30656,15 +30765,15 @@ CPyL3: ;
     cpy_r_r12 = (void *)&cpy_r_r11;
     int64_t cpy_r_r13[2] = {7, 8};
     cpy_r_r14 = (void *)&cpy_r_r13;
-    cpy_r_r15 = CPyStatics[551]; /* (('a_sync', 'a_sync', 'a_sync'),
+    cpy_r_r15 = CPyStatics[552]; /* (('a_sync', 'a_sync', 'a_sync'),
                                     ('multicall', 'multicall', 'multicall')) */
     cpy_r_r16 = CPyStatic_gather___globals;
-    cpy_r_r17 = CPyStatics[461]; /* 'y/utils/gather.py' */
+    cpy_r_r17 = CPyStatics[463]; /* 'y/utils/gather.py' */
     cpy_r_r18 = CPyStatics[31]; /* '<module>' */
     cpy_r_r19 = CPyImport_ImportMany(cpy_r_r15, cpy_r_r12, cpy_r_r16, cpy_r_r17, cpy_r_r18, cpy_r_r14);
     if (!cpy_r_r19) goto CPyL19;
-    cpy_r_r20 = CPyStatics[552]; /* ('stuck_coro_debugger',) */
-    cpy_r_r21 = CPyStatics[463]; /* 'y._decorators' */
+    cpy_r_r20 = CPyStatics[553]; /* ('stuck_coro_debugger',) */
+    cpy_r_r21 = CPyStatics[465]; /* 'y._decorators' */
     cpy_r_r22 = CPyStatic_gather___globals;
     cpy_r_r23 = CPyImport_ImportFromMany(cpy_r_r21, cpy_r_r20, cpy_r_r20, cpy_r_r22);
     if (unlikely(cpy_r_r23 == NULL)) {
@@ -30675,7 +30784,7 @@ CPyL3: ;
     CPy_INCREF(CPyModule_y____decorators);
     CPy_DECREF(cpy_r_r23);
     cpy_r_r24 = CPyModule_multicall;
-    cpy_r_r25 = CPyStatics[464]; /* 'Call' */
+    cpy_r_r25 = CPyStatics[466]; /* 'Call' */
     cpy_r_r26 = CPyObject_GetAttr(cpy_r_r24, cpy_r_r25);
     if (unlikely(cpy_r_r26 == NULL)) {
         CPy_AddTraceback("y/utils/gather.py", "<module>", 13, CPyStatic_gather___globals);
@@ -30684,7 +30793,7 @@ CPyL3: ;
     CPyStatic_gather___Call = cpy_r_r26;
     CPy_INCREF(CPyStatic_gather___Call);
     cpy_r_r27 = CPyStatic_gather___globals;
-    cpy_r_r28 = CPyStatics[464]; /* 'Call' */
+    cpy_r_r28 = CPyStatics[466]; /* 'Call' */
     cpy_r_r29 = CPyDict_SetItem(cpy_r_r27, cpy_r_r28, cpy_r_r26);
     CPy_DECREF(cpy_r_r26);
     cpy_r_r30 = cpy_r_r29 >= 0;
@@ -30693,7 +30802,7 @@ CPyL3: ;
         goto CPyL19;
     }
     cpy_r_r31 = CPyModule_a_sync;
-    cpy_r_r32 = CPyStatics[465]; /* 'igather' */
+    cpy_r_r32 = CPyStatics[467]; /* 'igather' */
     cpy_r_r33 = CPyObject_GetAttr(cpy_r_r31, cpy_r_r32);
     if (unlikely(cpy_r_r33 == NULL)) {
         CPy_AddTraceback("y/utils/gather.py", "<module>", 15, CPyStatic_gather___globals);
@@ -30702,7 +30811,7 @@ CPyL3: ;
     CPyStatic_gather___igather = cpy_r_r33;
     CPy_INCREF(CPyStatic_gather___igather);
     cpy_r_r34 = CPyStatic_gather___globals;
-    cpy_r_r35 = CPyStatics[465]; /* 'igather' */
+    cpy_r_r35 = CPyStatics[467]; /* 'igather' */
     cpy_r_r36 = CPyDict_SetItem(cpy_r_r34, cpy_r_r35, cpy_r_r33);
     CPy_DECREF(cpy_r_r33);
     cpy_r_r37 = cpy_r_r36 >= 0;
@@ -30711,14 +30820,14 @@ CPyL3: ;
         goto CPyL19;
     }
     cpy_r_r38 = CPyStatic_gather___globals;
-    cpy_r_r39 = CPyStatics[455]; /* '_gather_methods_brownie' */
+    cpy_r_r39 = CPyStatics[457]; /* '_gather_methods_brownie' */
     cpy_r_r40 = CPyDict_GetItem(cpy_r_r38, cpy_r_r39);
     if (unlikely(cpy_r_r40 == NULL)) {
         CPy_AddTraceback("y/utils/gather.py", "<module>", 62, CPyStatic_gather___globals);
         goto CPyL19;
     }
     cpy_r_r41 = CPyStatic_gather___globals;
-    cpy_r_r42 = CPyStatics[462]; /* 'stuck_coro_debugger' */
+    cpy_r_r42 = CPyStatics[464]; /* 'stuck_coro_debugger' */
     cpy_r_r43 = CPyDict_GetItem(cpy_r_r41, cpy_r_r42);
     if (unlikely(cpy_r_r43 == NULL)) {
         CPy_AddTraceback("y/utils/gather.py", "<module>", 62, CPyStatic_gather___globals);
@@ -30734,7 +30843,7 @@ CPyL3: ;
     }
     CPy_DECREF(cpy_r_r40);
     cpy_r_r47 = CPyStatic_gather___globals;
-    cpy_r_r48 = CPyStatics[455]; /* '_gather_methods_brownie' */
+    cpy_r_r48 = CPyStatics[457]; /* '_gather_methods_brownie' */
     cpy_r_r49 = CPyDict_SetItem(cpy_r_r47, cpy_r_r48, cpy_r_r46);
     CPy_DECREF(cpy_r_r46);
     cpy_r_r50 = cpy_r_r49 >= 0;
@@ -30743,14 +30852,14 @@ CPyL3: ;
         goto CPyL19;
     }
     cpy_r_r51 = CPyStatic_gather___globals;
-    cpy_r_r52 = CPyStatics[453]; /* '_gather_methods_raw' */
+    cpy_r_r52 = CPyStatics[455]; /* '_gather_methods_raw' */
     cpy_r_r53 = CPyDict_GetItem(cpy_r_r51, cpy_r_r52);
     if (unlikely(cpy_r_r53 == NULL)) {
         CPy_AddTraceback("y/utils/gather.py", "<module>", 101, CPyStatic_gather___globals);
         goto CPyL19;
     }
     cpy_r_r54 = CPyStatic_gather___globals;
-    cpy_r_r55 = CPyStatics[462]; /* 'stuck_coro_debugger' */
+    cpy_r_r55 = CPyStatics[464]; /* 'stuck_coro_debugger' */
     cpy_r_r56 = CPyDict_GetItem(cpy_r_r54, cpy_r_r55);
     if (unlikely(cpy_r_r56 == NULL)) {
         CPy_AddTraceback("y/utils/gather.py", "<module>", 101, CPyStatic_gather___globals);
@@ -30766,7 +30875,7 @@ CPyL3: ;
     }
     CPy_DECREF(cpy_r_r53);
     cpy_r_r60 = CPyStatic_gather___globals;
-    cpy_r_r61 = CPyStatics[453]; /* '_gather_methods_raw' */
+    cpy_r_r61 = CPyStatics[455]; /* '_gather_methods_raw' */
     cpy_r_r62 = CPyDict_SetItem(cpy_r_r60, cpy_r_r61, cpy_r_r59);
     CPy_DECREF(cpy_r_r59);
     cpy_r_r63 = cpy_r_r62 >= 0;
@@ -30803,6 +30912,7 @@ int CPyGlobalsInit(void)
     CPyModule_a_sync___a_sync = Py_None;
     CPyModule_brownie = Py_None;
     CPyModule_pony___orm = Py_None;
+    CPyModule_y = Py_None;
     CPyModule_y____db___utils___stringify = Py_None;
     CPyModule_builtins = Py_None;
     CPyModule_datetime = Py_None;
@@ -30877,7 +30987,7 @@ int CPyGlobalsInit(void)
     return 0;
 }
 
-PyObject *CPyStatics[553];
+PyObject *CPyStatics[554];
 const char * const CPyLit_Str[] = {
     "\004\006commit\017CommitException\020OperationalError\017UnexpectedError",
     "\005\020%s.%s got %s: %s\n__module__\b__name__\022database is locked\005sleep",
@@ -30887,34 +30997,34 @@ const char * const CPyLit_Str[] = {
     "\a\amaxsize\001 \003zip\023loaded %s %s for %s\021result_count_wrap\bbuiltins\alogging",
     "\a\004time\023y/_db/decorators.py\b<module>\tfunctools\bCallable\005Final\bIterable",
     "\005\aTypeVar\006typing\tParamSpec\021typing_extensions\031PruningThreadPoolExecutor",
-    "\b\rASyncFunction\ra_sync.a_sync\005chain\abrownie\bpony.orm\002_T\002_P\005DEBUG",
-    "\a\tgetLogger\006logger\awarning\vlog_warning\005debug\tlog_debug\020ydb_read_threads",
-    "\003\021ydb_write_threads\027db_session_retry_locked\026a_sync_read_db_session",
-    "\003\021db_session_cached\r.result_count\024_result_count_logger",
-    "\002\032_result_count_logger_debug\fisEnabledFor",
-    "\006#_result_count_logger_is_enabled_for\002id\v_CHAIN_INFO\004null\bpostgres\001\'",
-    "\n\b\'::bytea\006sqlite\002X\'\003hex\023NotImplementedError\aDecimal\bdatetime\001(\001,\001)",
+    "\005\rASyncFunction\ra_sync.a_sync\005chain\abrownie\bpony.orm",
+    "\t\025ENVIRONMENT_VARIABLES\004ENVS\001y\002_T\002_P\005DEBUG\tgetLogger\006logger\awarning",
+    "\005\vlog_warning\005debug\tlog_debug\bpostgres\020ydb read threads",
+    "\003\020ydb_read_threads\021ydb write threads\021ydb_write_threads",
+    "\003\027db_session_retry_locked\026a_sync_read_db_session\021db_session_cached",
+    "\003\r.result_count\024_result_count_logger\032_result_count_logger_debug",
+    "\005\fisEnabledFor#_result_count_logger_is_enabled_for\002id\v_CHAIN_INFO\004null",
+    "\v\001\'\b\'::bytea\006sqlite\002X\'\003hex\023NotImplementedError\aDecimal\bdatetime\001(\001,\001)",
     "\004\026insert or ignore into \002 (\t) values \finsert into ",
     "\a\027 on conflict do nothing\btimezone\adecimal\003Any\003utc\003UTC\nastimezone",
-    "\a\tisoformat\005errno\017y/_db/config.py\005mkdir\004path\002os\025ENVIRONMENT_VARIABLES",
-    "\a\004ENVS\001y\001~\nexpanduser\r/.ypricemagic\022DEFAULT_SQLITE_DIR\vdb_provider",
-    "\a\016_using_default\aOSError\001e\006EEXIST\bprovider\bfilename\tcreate_db",
-    "\a\023connection_settings\004host\004user\bpassword\bdatabase\004port\rEnvVarFactory",
-    "\006\ncreate_env\ntyped_envs\vYPRICEMAGIC\005_envs\tCACHE_TTL\averbose",
-    "\003\022CONTRACT_CACHE_TTL\022GETLOGS_BATCH_SIZE\vGETLOGS_DOP",
-    "\003\026CHECKSUM_CACHE_MAXSIZE\vDB_PROVIDER\vSQLITE_PATH",
-    "\006 /.ypricemagic/ypricemagic.sqlite\aDB_HOST\000\aDB_PORT\aDB_USER\vDB_PASSWORD",
-    "\005\vDB_DATABASE\vypricemagic\nSKIP_CACHE\016SKIP_YPRICEAPI\nValueError",
-    "\005\033 is not a valid ETH address\bchecksum\003run\rGeneratorExit\rStopIteration",
-    "\t\nissubclass\bHexBytes\0010\0020x\bOptional\003Set\tcchecksum\bhexbytes\fy/convert.py",
-    "\005\nAnyAddress\017ChecksumAddress\nHexAddress\neth_typing\016AnyAddressType",
-    "\004\vy.datatypes\023to_checksum_address\022ThreadPoolExecutor\020_checksum_thread",
-    "\006\017_is_checksummed\023_is_not_checksummed\005token\005block\texception\t__class__",
-    "\006\aNetwork\005super\b__init__\020 while fetching \tprintable\n at block ",
-    "\005\023No price found for \aaddress\n is not a \004_msg\017BrownieContract",
-    "\003\rfrom_explorer\rCompilerError\tException",
-    "\002*invalid literal for int() with base 16: \'\'\027list index out of range",
-    "\001\027pop from an empty deque",
+    "\b\tisoformat\005errno\017y/_db/config.py\005mkdir\004path\002os\001~\nexpanduser",
+    "\006\r/.ypricemagic\022DEFAULT_SQLITE_DIR\vdb_provider\016_using_default\aOSError\001e",
+    "\a\006EEXIST\bprovider\bfilename\tcreate_db\023connection_settings\004host\004user",
+    "\006\bpassword\bdatabase\004port\rEnvVarFactory\ncreate_env\ntyped_envs",
+    "\005\vYPRICEMAGIC\005_envs\tCACHE_TTL\averbose\022CONTRACT_CACHE_TTL",
+    "\004\022GETLOGS_BATCH_SIZE\vGETLOGS_DOP\026CHECKSUM_CACHE_MAXSIZE\vDB_PROVIDER",
+    "\006\vSQLITE_PATH /.ypricemagic/ypricemagic.sqlite\aDB_HOST\000\aDB_PORT\aDB_USER",
+    "\005\vDB_PASSWORD\vDB_DATABASE\vypricemagic\nSKIP_CACHE\016SKIP_YPRICEAPI",
+    "\005\nValueError\033 is not a valid ETH address\bchecksum\003run\rGeneratorExit",
+    "\b\rStopIteration\nissubclass\bHexBytes\0010\0020x\bOptional\003Set\tcchecksum",
+    "\005\bhexbytes\fy/convert.py\nAnyAddress\017ChecksumAddress\nHexAddress",
+    "\004\neth_typing\016AnyAddressType\vy.datatypes\023to_checksum_address",
+    "\003\022ThreadPoolExecutor\020_checksum_thread\017_is_checksummed",
+    "\a\023_is_not_checksummed\005token\005block\texception\t__class__\aNetwork\005super",
+    "\005\b__init__\020 while fetching \tprintable\n at block \023No price found for ",
+    "\006\aaddress\n is not a \004_msg\017BrownieContract\rfrom_explorer\rCompilerError",
+    "\002\tException*invalid literal for int() with base 16: \'\'",
+    "\002\027list index out of range\027pop from an empty deque",
     "\0016\'UsingForDirective\' object has no attribute \'typeName\'",
     "\003!Contract source code not verified\025has not been verified\rUniswapV2Pool",
     "\003\027y.prices.dex.uniswap.v2&_ChecksumASyncSingletonMeta__instances\003pop",
@@ -31084,24 +31194,24 @@ const char * const CPyLit_Bytes[] = {
     "",
 };
 const char * const CPyLit_Int[] = {
-    "\02310\00012\0003600\0000\00032\000100000\0001\00025\00056\00066\000100\000128\000137\000250\0001285\0008453\00042161\00043114\0001666600000",
+    "\02210\0003600\0000\00032\000100000\0001\00025\00056\00066\000100\000128\000137\000250\0001285\0008453\00042161\00043114\0001666600000",
     "\0031313161554\0001000\0004",
     "",
 };
 const double CPyLit_Float[] = {0};
 const double CPyLit_Complex[] = {0};
 const int CPyLit_Tuple[] = {
-    65, 2, 19, 20, 1, 22, 3, 28, 28, 28, 3, 29, 29, 29, 2, 490, 491, 2,
+    65, 2, 19, 20, 1, 22, 3, 28, 28, 28, 3, 29, 29, 29, 2, 491, 492, 2,
     21, 14, 4, 33, 34, 35, 36, 1, 38, 2, 40, 18, 1, 41, 1, 43, 6, 4, 5,
-    12, 6, 3, 16, 2, 76, 85, 1, 75, 3, 87, 34, 35, 3, 92, 92, 92, 1, 503,
-    2, 94, 95, 1, 34, 1, 97, 1, 98, 1, 95, 2, 118, 119, 2, 19, 124, 1, 19,
-    1, 21, 3, 34, 151, 152, 3, 18, 18, 18, 3, 153, 153, 153, 3, 154, 154,
-    154, 3, 515, 516, 517, 3, 156, 157, 158, 1, 160, 1, 171, 1, 191, 1,
-    490, 1, 206, 5, 208, 87, 34, 151, 209, 1, 210, 1, 181, 1, 183, 2, 212,
-    157, 1, 196, 1, 269, 3, 34, 151, 209, 1, 285, 1, 293, 4, 34, 151, 152,
-    313, 1, 515, 1, 284, 4, 271, 282, 315, 316, 1, 220, 1, 303, 1, 306, 1,
-    297, 1, 292, 1, 311, 2, 168, 454, 1, 456, 1, 454, 1, 457, 6, 87, 34,
-    35, 458, 151, 459, 3, 460, 460, 460, 2, 515, 550, 1, 462
+    12, 6, 3, 16, 1, 46, 1, 47, 2, 81, 90, 1, 80, 3, 92, 34, 35, 3, 97,
+    97, 97, 1, 506, 2, 99, 100, 1, 34, 1, 100, 2, 120, 121, 2, 19, 126, 1,
+    19, 1, 21, 3, 34, 153, 154, 3, 18, 18, 18, 3, 155, 155, 155, 3, 156,
+    156, 156, 3, 516, 517, 518, 3, 158, 159, 160, 1, 162, 1, 173, 1, 193,
+    1, 491, 1, 208, 5, 210, 92, 34, 153, 211, 1, 212, 1, 183, 1, 185, 2,
+    214, 159, 1, 198, 1, 271, 3, 34, 153, 211, 1, 287, 1, 295, 4, 34, 153,
+    154, 315, 1, 516, 1, 286, 4, 273, 284, 317, 318, 1, 222, 1, 305, 1,
+    308, 1, 299, 1, 294, 1, 313, 2, 170, 456, 1, 458, 1, 456, 1, 459, 6,
+    92, 34, 35, 460, 153, 461, 3, 462, 462, 462, 2, 516, 551, 1, 464
 };
 const int CPyLit_FrozenSet[] = {0};
 CPyModule *CPyModule_y____db___decorators_internal = NULL;
@@ -31117,6 +31227,7 @@ CPyModule *CPyModule_a_sync;
 CPyModule *CPyModule_a_sync___a_sync;
 CPyModule *CPyModule_brownie;
 CPyModule *CPyModule_pony___orm;
+CPyModule *CPyModule_y;
 CPyModule *CPyModule_y____db___utils___stringify_internal = NULL;
 CPyModule *CPyModule_y____db___utils___stringify;
 PyObject *CPyStatic_stringify___globals;
@@ -31127,7 +31238,6 @@ CPyModule *CPyModule_y____db___config;
 PyObject *CPyStatic_config___globals;
 CPyModule *CPyModule_errno;
 CPyModule *CPyModule_os;
-CPyModule *CPyModule_y;
 CPyModule *CPyModule_y___ENVIRONMENT_VARIABLES_internal = NULL;
 CPyModule *CPyModule_y___ENVIRONMENT_VARIABLES;
 PyObject *CPyStatic_ENVIRONMENT_VARIABLES___globals;

--- a/build/__native_internal_e48b665766e5f62102a4.h
+++ b/build/__native_internal_e48b665766e5f62102a4.h
@@ -6,7 +6,7 @@
 
 int CPyGlobalsInit(void);
 
-extern PyObject *CPyStatics[553];
+extern PyObject *CPyStatics[554];
 extern const char * const CPyLit_Str[];
 extern const char * const CPyLit_Bytes[];
 extern const char * const CPyLit_Int[];
@@ -27,6 +27,7 @@ extern CPyModule *CPyModule_a_sync;
 extern CPyModule *CPyModule_a_sync___a_sync;
 extern CPyModule *CPyModule_brownie;
 extern CPyModule *CPyModule_pony___orm;
+extern CPyModule *CPyModule_y;
 extern CPyModule *CPyModule_y____db___utils___stringify_internal;
 extern CPyModule *CPyModule_y____db___utils___stringify;
 extern PyObject *CPyStatic_stringify___globals;
@@ -37,7 +38,6 @@ extern CPyModule *CPyModule_y____db___config;
 extern PyObject *CPyStatic_config___globals;
 extern CPyModule *CPyModule_errno;
 extern CPyModule *CPyModule_os;
-extern CPyModule *CPyModule_y;
 extern CPyModule *CPyModule_y___ENVIRONMENT_VARIABLES_internal;
 extern CPyModule *CPyModule_y___ENVIRONMENT_VARIABLES;
 extern PyObject *CPyStatic_ENVIRONMENT_VARIABLES___globals;

--- a/y/_db/decorators.py
+++ b/y/_db/decorators.py
@@ -4,7 +4,7 @@ from functools import lru_cache, wraps
 from typing import Callable, Final, Iterable, TypeVar
 from typing_extensions import ParamSpec
 
-from a_sync import PruningThreadPoolExecutor, a_sync
+from a_sync import a_sync
 from a_sync.a_sync import ASyncFunction
 from brownie import chain
 from pony.orm import (
@@ -16,6 +16,8 @@ from pony.orm import (
     db_session,
 )
 
+from y._db.common import make_executor
+
 
 _T = TypeVar("_T")
 _P = ParamSpec("_P")
@@ -26,8 +28,8 @@ logger: Final = logging.getLogger(__name__)
 log_warning: Final = logger.warning
 log_debug: Final = logger.debug
 
-ydb_read_threads: Final = PruningThreadPoolExecutor(12)
-ydb_write_threads: Final = PruningThreadPoolExecutor(12)
+ydb_read_threads: Final = make_executor(4, 12, "ydb read threads")
+ydb_write_threads: Final = make_executor(4, 12, "ydb write threads")
 
 
 def retry_locked(callable: Callable[_P, _T]) -> Callable[_P, _T]:

--- a/y/_db/decorators.py
+++ b/y/_db/decorators.py
@@ -28,8 +28,12 @@ logger: Final = logging.getLogger(__name__)
 log_warning: Final = logger.warning
 log_debug: Final = logger.debug
 
-ydb_read_threads: Final = PruningThreadPoolExecutor(12 if ENVS.DB_PROVIDER == "postgres" else 4, "ydb read threads")
-ydb_write_threads: Final = PruningThreadPoolExecutor(12 if ENVS.DB_PROVIDER == "postgres" else 4, "ydb write threads")
+ydb_read_threads: Final = PruningThreadPoolExecutor(
+    12 if ENVS.DB_PROVIDER == "postgres" else 4, "ydb read threads"
+)
+ydb_write_threads: Final = PruningThreadPoolExecutor(
+    12 if ENVS.DB_PROVIDER == "postgres" else 4, "ydb write threads"
+)
 
 
 def retry_locked(callable: Callable[_P, _T]) -> Callable[_P, _T]:

--- a/y/_db/decorators.py
+++ b/y/_db/decorators.py
@@ -4,7 +4,7 @@ from functools import lru_cache, wraps
 from typing import Callable, Final, Iterable, TypeVar
 from typing_extensions import ParamSpec
 
-from a_sync import a_sync
+from a_sync import PruningThreadPoolExecutor, a_sync
 from a_sync.a_sync import ASyncFunction
 from brownie import chain
 from pony.orm import (
@@ -16,7 +16,7 @@ from pony.orm import (
     db_session,
 )
 
-from y._db.common import make_executor
+from y import ENVIRONMENT_VARIABLES as ENVS
 
 
 _T = TypeVar("_T")
@@ -28,8 +28,8 @@ logger: Final = logging.getLogger(__name__)
 log_warning: Final = logger.warning
 log_debug: Final = logger.debug
 
-ydb_read_threads: Final = make_executor(4, 12, "ydb read threads")
-ydb_write_threads: Final = make_executor(4, 12, "ydb write threads")
+ydb_read_threads: Final = PruningThreadPoolExecutor(12 if ENVS.DB_PROVIDER == "postgres" else 4, "ydb read threads")
+ydb_write_threads: Final = PruningThreadPoolExecutor(12 if ENVS.DB_PROVIDER == "postgres" else 4, "ydb write threads")
 
 
 def retry_locked(callable: Callable[_P, _T]) -> Callable[_P, _T]:


### PR DESCRIPTION
This should help prevent some 'database is locked' errs and subsequent retries