### PR TITLE
fix: downstream poetry issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 aiosqlite
 bobs_lazy_logging==0.0.4
 cchecksum>=0.0.3
-checksum_dict>=2.1.2,<3
+checksum_dict>=2.1.10.dev0,<3
 dank_mids>=4.20.161
 eth-brownie>=1.21.0,<1.23
 eth_retry>=0.2.1


### PR DESCRIPTION
Something went wrong with my versioning for `checksum-dict` lib and my automated CICD published v2.1.9 as v2.1.10.dev0

This causes installation issues for projects using ypricemagic.

This PR fixes those issues.