### PR TITLE
fix: decrease _block_executor thread pool size 4 -> 2 when using sql…

### DIFF
--- a/y/_db/utils/utils.py
+++ b/y/_db/utils/utils.py
@@ -26,7 +26,7 @@ CHAINID = chain.id
 del chain
 
 
-_block_executor = make_executor(4, 8, "ypricemagic db executor [block]")
+_block_executor = make_executor(2, 8, "ypricemagic db executor [block]")
 _timestamp_executor = make_executor(1, 4, "ypricemagic db executor [timestamp]")
 
 


### PR DESCRIPTION
…ite backend

This will help reduce the "db is locked" errors that we frequently must retry