### PR TITLE
[WIP] fix: iDAI oracle is zero address

### DIFF
--- a/y/prices/lending/compound.py
+++ b/y/prices/lending/compound.py
@@ -220,7 +220,9 @@ class CToken(ERC20):
             self.troller.oracle(block, asynchronous=True), self.__underlying__
         )
         if oracle is None:
-            return await magic.get_price(underlying.address, block, skip_cache=skip_cache, sync=False)
+            return await magic.get_price(
+                underlying.address, block, skip_cache=skip_cache, sync=False
+            )
 
         price, underlying_decimals = await cgather(
             oracle.getUnderlyingPrice.coroutine(self.address, block_identifier=block),


### PR DESCRIPTION
The Ironbank comptroller is returning the zero address for the iDAI (0x8e595470Ed749b85C6F7669de83EAe304C2ec68F ) oracle at block 21894572

Edit: The comptroller was migrated and I need to build handling for this

WIP