### PR TITLE
feat: remove semaphore from BalancerV2.deepest_pool_for

### DIFF
--- a/y/prices/dex/balancer/v2.py
+++ b/y/prices/dex/balancer/v2.py
@@ -729,8 +729,6 @@ class BalancerV2(BalancerABC[BalancerV2Pool]):
                 token_address, block, skip_cache=skip_cache, sync=False
             )
 
-    # NOTE: we need a tiny semaphore here because balancer is super arduous and every unpricable token must pass thru this section
-    @a_sync.Semaphore(10)
     @stuck_coro_debugger
     async def deepest_pool_for(
         self, token_address: Address, block: Optional[Block] = None


### PR DESCRIPTION
Recent optimizations I've made across various parts of the stack render this no longer necessary, and potentially inefficient