### PR TITLE
feat: remove semaphore from UniswapV2Pool.check_liquidity

### DIFF
--- a/y/prices/dex/uniswap/v2.py
+++ b/y/prices/dex/uniswap/v2.py
@@ -304,7 +304,7 @@ class UniswapV2Pool(ERC20):
                 raise Exception("how did we get here?") from None
 
     @stuck_coro_debugger
-    @a_sync.a_sync(ram_cache_maxsize=100_000, ram_cache_ttl=60 * 60, semaphore=25_000)
+    @a_sync.a_sync(ram_cache_maxsize=100_000, ram_cache_ttl=60 * 60)
     async def check_liquidity(self, token: Address, block: Block) -> int:
         """
         Check the liquidity of a specific token in the pool at a given block.


### PR DESCRIPTION
Recent optimizations I've made across the stack render this no longer necessary, and potentially quite inefficient in some cases