### PR TITLE
Remove unnecessary blanket `# type: ignore` comments

### DIFF
--- a/y/classes/singleton.py
+++ b/y/classes/singleton.py
@@ -65,7 +65,7 @@ class ChecksumASyncSingletonMeta(ASyncMeta, Generic[T]):
         cls.__locks_lock: threading.Lock = threading.Lock()
         """A lock to ensure thread-safe access to the locks dictionary."""
 
-    def __call__(cls, address: AnyAddressOrContract, *args, **kwargs) -> T:  # type: ignore
+    def __call__(cls, address: AnyAddressOrContract, *args, **kwargs) -> T:
         """
         Create or retrieve a singleton instance for the given address.
 

--- a/y/contracts.py
+++ b/y/contracts.py
@@ -636,7 +636,7 @@ class Contract(dank_mids.Contract, metaclass=ChecksumAddressSingletonMeta):
             >>> contract.name()
             'Dai Stablecoin'
         """
-        _ContractBase.__init__(self, None, build, {})  # type: ignore
+        _ContractBase.__init__(self, None, build, {})
         _DeployedContractBase.__init__(self, build["address"], owner, None)  # type: ignore [type-var]
         if persist:
             _add_deployment(self)


### PR DESCRIPTION
### Motivation

- Remove unspecific `# type: ignore` comments so mypy can report the actual typing issues at those call sites.
- Narrow ignores to be explicit only when necessary to avoid masking real type errors.

### Description

- Deleted an unused blanket `# type: ignore` on the `_ContractBase.__init__` call in `y/contracts.py`.
- Removed an unnecessary `# type: ignore` on `ChecksumASyncSingletonMeta.__call__` in `y/classes/singleton.py`.
- Kept other typed ignores with explicit error codes intact and only removed the two unspecific ignores.

### Testing

- Ran `mypy y/classes/singleton.py --follow-imports=skip --ignore-missing-imports` which reported no issues for that file.
- Ran `mypy y/classes/singleton.py --follow-imports=skip --ignore-missing-imports --check-untyped-defs` which failed with one annotation-required error for `__locks`.
- Ran `mypy y/contracts.py --follow-imports=skip --ignore-missing-imports` which reported existing type errors in the file but no errors at the removed ignore site.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966357f32648331828c48dca18897f8)