### PR TITLE
Fix YAML syntax in add_a_chain issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/add_a_chain.yml
+++ b/.github/ISSUE_TEMPLATE/add_a_chain.yml
@@ -57,7 +57,7 @@ body:
             - [ ] Add the symbol for the wrapped form of the network's gas token. For example, on Ethereum, Optimism, and Arbitrum it would be "WETH" but on Polygon it is "WMATIC"
 
         - label: "Add Uniswap V2 deployment details and any forks to `./y/prices/dex/uniswap/v2_forks.py`"
-          description:
+          description: |
             - [ ] Add the factory and router addresses for Uniswap V2 and all known direct forks
 
         - label: "Add Uniswap V3 deployment details to `./y/prices/dex/uniswap/v3.py`"


### PR DESCRIPTION
### Motivation
- Resolve a YAML parsing error in the GitHub issue template that caused a syntax error during workflow validation.

### Description
- Add a block scalar `|` to the `description` field for the Uniswap V2 checklist in `.github/ISSUE_TEMPLATE/add_a_chain.yml` so collection items align and the YAML parses correctly.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969da449ca4833194ffc8baa16ec2b8)