### PR TITLE
docs: document y.stuck? logger

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,5 +6,6 @@ All agents must follow these rules:
 2) PR titles must be descriptive and follow Conventional Commits-style prefixes:
    - Common: `feat:`, `fix:`, `chore:`, `refactor:`, `docs:`, `test:`, `perf:`
    - Support titles: `fix(docs):`, `fix(benchmarks):`, `fix(cicd):`
+3) When adding or refactoring async RPC/price-fetching code, keep or add `y._decorators.stuck_coro_debugger` so the `y.stuck?` DEBUG logger continues emitting "still executing" messages at the default 5-minute interval (via `a_sync.debugging.stuck_coro_debugger`).
 
 Reference: https://www.conventionalcommits.org/en/v1.0.0/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,22 @@
 
+## y.stuck? logger
+
+ypricemagic wraps many long-running async coroutines with `y._decorators.stuck_coro_debugger`, which is a thin wrapper around `a_sync.debugging.stuck_coro_debugger`. That wrapper uses a dedicated logger named `y.stuck?`.
+
+What it does:
+- It only runs when the logger is enabled for DEBUG.
+- After a coroutine has been running for 5 minutes, it logs `module.function still executing after Xm with args ... kwargs ...` every 5 minutes until completion.
+
+Enable it locally when debugging slow RPCs or stuck price fetches:
+```python
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logging.getLogger("y.stuck?").setLevel(logging.DEBUG)
+```
+
+If you add new async RPC or price-fetching functions that might stall, prefer `@stuck_coro_debugger` from `y._decorators` so this logger stays consistent across the codebase.
+
 ## Adding new protocols
 
 I will add info to this document over time. For now, it will be sparse. Very sparse.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ prices = await get_prices(tokens, block, sync=False)
 
 See the [docs](https://bobthebuidler.github.io/ypricemagic) for more usage information.
 
+## Debug logging
+If you need to spot long-running async calls, enable the `y.stuck?` logger at DEBUG to get periodic "still executing" messages. Details: [y.stuck? logger](CONTRIBUTING.md#y-stuck-logger).
+
 ## Extras
 You can also import protocol specific modules. For example:
 ```python


### PR DESCRIPTION
## Summary
- add README note linking to detailed y.stuck? logger docs
- document y.stuck? logger behavior and enablement in CONTRIBUTING
- add AGENTS guidance to keep stuck-coro decorator on async RPC/price paths

## Testing
- not run (docs-only)
