### PR TITLE
fix: correct aave __contains__ async guard

### DIFF
--- a/y/prices/lending/aave.py
+++ b/y/prices/lending/aave.py
@@ -86,7 +86,7 @@ class AaveMarketBase(ContractBase):
             >>> token in market
             True
         """
-        if not self.asynchronous:
+        if self.asynchronous:
             cls = self.__class__.__name__
             raise RuntimeError(
                 f"'self.asynchronous' must be False to use {cls}.__contains__.\nYou may wish to use {cls}.is_atoken instead."


### PR DESCRIPTION
## Summary
- fix AaveMarketBase.__contains__ to guard only when asynchronous

## Testing
- `pytest tests/prices/lending/test_aave.py -q` *(fails: ImportError: cannot import name 'WebsocketProvider' from 'web3')*