### PR TITLE
docs: add agent rule for Local pip install . generates build/;

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,4 +20,5 @@ All agents must follow these rules:
 14) Centralize pytest settings (flags, markers, ignore patterns, and targets) in pyproject.toml, pytest.ini, setup.cfg, or tox.ini; workflows/hooks should call pytest without inline args.
 15) If the branch you're assigned to work on is from a remote (ie origin/master or upstream/awesome-feature) you must ensure you fetch and pull from the remote before you begin your work.
 
+16) Local pip install . generates build/; clean up before closing a worktree to avoid dirty state.
 Reference: https://www.conventionalcommits.org/en/v1.0.0/


### PR DESCRIPTION
Summary:
- Add agent requirement: "Local pip install . generates build/; clean up before closing a worktree to avoid dirty state.".

Rationale:
- Clarify contributor expectations for this repo.

Details:
- Update AGENTS.md.
