### PR TITLE
fix: trim uniswap v2 helper ignore_pools logging

### DIFF
--- a/y/prices/dex/uniswap/v2.py
+++ b/y/prices/dex/uniswap/v2.py
@@ -446,13 +446,10 @@ def _log_factory_helper_failure(e: Exception, token_address, block, _ignore_pool
 def _summarize_ignore_pools(_ignore_pools, sample_size: int = 3) -> tuple[int, tuple[str, ...]]:
     if not _ignore_pools:
         return 0, ()
-    sample = []
-    for pool in islice(_ignore_pools, sample_size):
-        address = getattr(pool, "address", None)
-        if address is None:
-            address = pool
-        sample.append(str(address))
-    return len(_ignore_pools), tuple(sample)
+    sample = tuple(
+        str(getattr(pool, "address", pool)) for pool in islice(_ignore_pools, sample_size)
+    )
+    return len(_ignore_pools), sample
 
 
 class UniswapRouterV2(ContractBase):


### PR DESCRIPTION
## Summary
- reduce noisy helper failure logging by summarizing ignore_pools instead of dumping full pool objects

## Rationale
- Base startup logs were exploding due to SYMBOL_NOT_LOADED in pool __repr__; logging count/sample keeps failure context without spam

## Details
- add _summarize_ignore_pools and log ignore_pools_count + ignore_pools_sample in _log_factory_helper_failure

## Tests
- not run (pytest blocked pending Brownie network env/harness config)