### PR TITLE
fix: reduce ypriceapi chains cache TTL to 10 minutes

### DIFF
--- a/y/prices/utils/ypriceapi.py
+++ b/y/prices/utils/ypriceapi.py
@@ -28,6 +28,7 @@ AUTH_HEADERS_PRESENT: Final = all(AUTH_HEADERS.values())
 # some arbitrary amount of time in case the header is missing on unexpected 5xx responses
 ONE_MINUTE: Final = 60
 FIVE_MINUTES: Final = ONE_MINUTE * 5
+TEN_MINUTES: Final = ONE_MINUTE * 10
 ONE_HOUR: Final = ONE_MINUTE * 60
 FALLBACK_STR: Final = "Falling back to your node for pricing."
 
@@ -120,7 +121,7 @@ async def get_session() -> ClientSession:
     )
 
 
-@alru_cache(ttl=ONE_HOUR)
+@alru_cache(ttl=TEN_MINUTES)
 async def get_chains() -> dict[int, str]:
     """Get the supported chains from ypriceAPI.
 
@@ -138,7 +139,7 @@ async def get_chains() -> dict[int, str]:
     return {int(k): v for k, v in chains.items()}
 
 
-@alru_cache(ttl=ONE_HOUR)
+@alru_cache(ttl=TEN_MINUTES)
 async def chain_supported(chainid: int) -> bool:
     """Check if a chain is supported by ypriceAPI.
 


### PR DESCRIPTION
## Summary
Reduce the ypriceapi chain cache TTL from 1 hour to 10 minutes to limit how long transient `/chains` failures appear as unsupported networks.

## Changes
- Add a `TEN_MINUTES` constant and apply it to `get_chains` and `chain_supported` cache TTLs.

## Testing
- `make test-chainlink` (fails: `ImportError: cannot import name 'ContractName' from 'eth_typing'` via web3 pytest plugin)
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 make test-chainlink` (fails: `KeyError: 'BROWNIE_NETWORK'` from `tests/conftest.py`)

## Risk and rollback
Low risk; only cache TTL duration changes. Roll back by reverting the TTLs to `ONE_HOUR` in `y/prices/utils/ypriceapi.py`.
