### PR TITLE
fix(cicd): stop release builds warning on unused PyPy skip

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -102,8 +102,6 @@ jobs:
 
       - name: Build wheels
         env:
-          # Skip PyPy
-          CIBW_SKIP: pp*
           # On Linux: manylinux / musllinux arches
           CIBW_ARCHS_LINUX: ${{ matrix.cibw_archs_linux || '' }}
           # On Windows: AMD64 / x86


### PR DESCRIPTION
## Summary
- Remove the stale `CIBW_SKIP: pp*` setting from the release wheel workflow.

## Rationale
- cibuildwheel warns that `pp*` targets a group that is not enabled, so the selector has no effect.
- The workflow only builds CPython wheels today, so removing the skip keeps release behavior unchanged while cleaning up logs.

## Details
- Deleted the `# Skip PyPy` comment and `CIBW_SKIP: pp*` env var from `.github/workflows/release.yaml`.
- Left the existing manylinux, musllinux, macOS, and Windows wheel matrix unchanged.
- Validation: workflow-only change; confirmed the invalid PyPy skip selector is removed with `git diff --check`.