### PR TITLE
fix: make POA middleware setup idempotent for Web3 v7

### DIFF
--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -3,6 +3,7 @@ from uuid import uuid4
 
 import pytest
 from web3 import Web3
+from web3.exceptions import Web3ValueError
 
 from y.networks import Network
 from y.utils import middleware
@@ -65,14 +66,21 @@ def test_getcode_cache_middleware_class_can_be_added_to_web3_v7_onion():
 
 
 class _FakeMiddlewareOnion:
-    def __init__(self, exc=None):
+    def __init__(self, middlewares=(), exc=None, middlewares_after_error=()):
+        self.middlewares = list(middlewares)
         self.exc = exc
+        self.middlewares_after_error = list(middlewares_after_error)
         self.inject_calls = []
+
+    def as_tuple_of_middleware(self):
+        return tuple(self.middlewares)
 
     def inject(self, middleware_obj, layer):
         self.inject_calls.append((middleware_obj, layer))
         if self.exc is not None:
+            self.middlewares.extend(self.middlewares_after_error)
             raise self.exc
+        self.middlewares.insert(layer, middleware_obj)
 
 
 def test_setup_geth_poa_middleware_injects_v7_middleware(monkeypatch):
@@ -81,23 +89,57 @@ def test_setup_geth_poa_middleware_injects_v7_middleware(monkeypatch):
 
     middleware.setup_geth_poa_middleware()
 
-    assert onion.inject_calls == [(middleware._poa_middleware, 0)]
+    assert onion.inject_calls == [(middleware.ExtraDataToPOAMiddleware, 0)]
+    assert onion.as_tuple_of_middleware() == (middleware.ExtraDataToPOAMiddleware,)
 
 
-def test_setup_geth_poa_middleware_ignores_duplicate_unnamed_middleware(monkeypatch):
-    onion = _FakeMiddlewareOnion(ValueError("You can't add the same un-named instance twice"))
+def test_setup_geth_poa_middleware_is_idempotent(monkeypatch):
+    onion = _FakeMiddlewareOnion()
+    monkeypatch.setattr(middleware, "web3", SimpleNamespace(middleware_onion=onion))
+
+    middleware.setup_geth_poa_middleware()
+    middleware.setup_geth_poa_middleware()
+
+    assert onion.inject_calls == [(middleware.ExtraDataToPOAMiddleware, 0)]
+    assert onion.as_tuple_of_middleware() == (middleware.ExtraDataToPOAMiddleware,)
+
+
+def test_setup_geth_poa_middleware_noops_when_already_installed(monkeypatch):
+    onion = _FakeMiddlewareOnion((middleware.ExtraDataToPOAMiddleware,))
     monkeypatch.setattr(middleware, "web3", SimpleNamespace(middleware_onion=onion))
 
     middleware.setup_geth_poa_middleware()
 
-    assert onion.inject_calls == [(middleware._poa_middleware, 0)]
+    assert onion.inject_calls == []
+
+
+def test_setup_geth_poa_middleware_tolerates_race_when_middleware_now_installed(
+    monkeypatch,
+):
+    onion = _FakeMiddlewareOnion(
+        exc=ValueError("You can't add the same name again, use replace instead"),
+        middlewares_after_error=(middleware.ExtraDataToPOAMiddleware,),
+    )
+    monkeypatch.setattr(middleware, "web3", SimpleNamespace(middleware_onion=onion))
+
+    middleware.setup_geth_poa_middleware()
+
+    assert onion.inject_calls == [(middleware.ExtraDataToPOAMiddleware, 0)]
 
 
 def test_setup_geth_poa_middleware_reraises_other_value_errors(monkeypatch):
-    onion = _FakeMiddlewareOnion(ValueError("boom"))
+    onion = _FakeMiddlewareOnion(exc=ValueError("boom"))
     monkeypatch.setattr(middleware, "web3", SimpleNamespace(middleware_onion=onion))
 
     with pytest.raises(ValueError, match="boom"):
+        middleware.setup_geth_poa_middleware()
+
+
+def test_setup_geth_poa_middleware_reraises_other_web3_value_errors(monkeypatch):
+    onion = _FakeMiddlewareOnion(exc=Web3ValueError("boom"))
+    monkeypatch.setattr(middleware, "web3", SimpleNamespace(middleware_onion=onion))
+
+    with pytest.raises(Web3ValueError, match="boom"):
         middleware.setup_geth_poa_middleware()
 
 

--- a/y/utils/middleware.py
+++ b/y/utils/middleware.py
@@ -7,6 +7,7 @@ from brownie import chain, web3
 from requests import Session
 from requests.adapters import HTTPAdapter
 from web3 import HTTPProvider
+from web3.exceptions import Web3ValueError
 from web3.middleware import ExtraDataToPOAMiddleware
 from web3.middleware import Web3Middleware
 
@@ -172,11 +173,16 @@ def setup_geth_poa_middleware() -> None:
     See Also:
         - :class:`web3.middleware.ExtraDataToPOAMiddleware`
     """
+    middleware_onion = web3.middleware_onion
+    if ExtraDataToPOAMiddleware in middleware_onion.as_tuple_of_middleware():
+        return
+
     try:
-        web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
-    except ValueError as e:
-        if str(e) != "You can't add the same un-named instance twice":
-            raise
+        middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
+    except (ValueError, Web3ValueError):
+        if ExtraDataToPOAMiddleware in middleware_onion.as_tuple_of_middleware():
+            return
+        raise
 
 
 def remove_legacy_poa_middleware() -> None:


### PR DESCRIPTION
## Summary
- Make `setup_geth_poa_middleware()` idempotent against Web3 v7 middleware onion state.
- Replace fragile duplicate-error string matching with an explicit `ExtraDataToPOAMiddleware` presence check.
- Add focused tests for fresh install, repeated setup, preinstalled middleware, race-after-error, and unrelated error propagation.

## Rationale
Optimism imports call `setup_geth_poa_middleware()` during ypricemagic initialization. With Web3 v7.16.0, attempting to inject an already-installed `ExtraDataToPOAMiddleware` can raise `Web3ValueError: You can't add the same name again, use replace instead`, which was not covered by the previous old error-string check. The durable fix is to treat Web3 v7 onion state as the source of truth and only inject when the POA middleware is absent.

## Details
- Uses `web3.middleware_onion.as_tuple_of_middleware()` to detect existing `ExtraDataToPOAMiddleware` before injection.
- Re-checks the onion after `ValueError` / `Web3ValueError` during injection, returning only if the POA middleware is now present and otherwise re-raising.
- Keeps the fix narrow to Web3 v7 POA middleware setup and leaves `remove_legacy_poa_middleware()` unchanged.
- Tests were not run per user request; a temporary compiled install was created earlier but no test suite was executed after the final instruction to skip tests/compiling.